### PR TITLE
Doc: Inter-Service Lexicon

### DIFF
--- a/docs/arch/lexicon.md
+++ b/docs/arch/lexicon.md
@@ -2,8 +2,9 @@
 ## Inter-Service Lexicon
 
 - **Action**: a CI atomic unit. It contains infrastructure, environment and commands to execute.
+- **Action status**: the state of the execution of an action (running, successful, failed).
 - **Agent**: an agent is a computing node registered with the scheduler.
 - **Agent pool**: the set of all registered agents. It is a scheduler's entire knowledge about available computing resources.
-- **Scheduling**: selection of an agent on which to execute an action.
-- **Action status**: the state of the execution of an action (running, successful, failed).
 - **Pipeline**: a set of actions to be executed. It is declared as a YAML file.
+- **Scheduling**: selection of an agent on which to execute an action.
+

--- a/docs/arch/lexicon.md
+++ b/docs/arch/lexicon.md
@@ -5,5 +5,5 @@
 - Agent: an agent is a computing node registered with the scheduler.
 - Agent pool: the set of all registered agents. It is a scheduler's entire knowledge about available computing resources.
 - Scheduling: selection of an agent on which to execute an action.
-- Step execution stage: the state of the execution of an action (running, successful, failed).
+- Action status: the state of the execution of an action (running, successful, failed).
 

--- a/docs/arch/lexicon.md
+++ b/docs/arch/lexicon.md
@@ -1,0 +1,9 @@
+
+## Inter-Service Lexicon
+
+- Action: a CI atomic unit. It contains infrastructure, environment and commands to execute.
+- Agent: an agent is a computing node registered with the scheduler.
+- Agent pool: the set of all registered agents. It is a scheduler's entire knowledge about available computing resources.
+- Scheduling: selection of an agent on which to execute an action.
+- Step execution stage: the state of the execution of an action (running, successful, failed).
+

--- a/docs/arch/lexicon.md
+++ b/docs/arch/lexicon.md
@@ -1,9 +1,9 @@
 
 ## Inter-Service Lexicon
 
-- Action: a CI atomic unit. It contains infrastructure, environment and commands to execute.
-- Agent: an agent is a computing node registered with the scheduler.
-- Agent pool: the set of all registered agents. It is a scheduler's entire knowledge about available computing resources.
-- Scheduling: selection of an agent on which to execute an action.
-- Action status: the state of the execution of an action (running, successful, failed).
-
+- **Action**: a CI atomic unit. It contains infrastructure, environment and commands to execute.
+- **Agent**: an agent is a computing node registered with the scheduler.
+- **Agent pool**: the set of all registered agents. It is a scheduler's entire knowledge about available computing resources.
+- **Scheduling**: selection of an agent on which to execute an action.
+- **Action status**: the state of the execution of an action (running, successful, failed).
+- **Pipeline**: a set of actions to be executed. It is declared as a YAML file.


### PR DESCRIPTION
Inter-service Lexicon. Markdown lexic for the vocabulary common to the four SealCI services (Monitor, Controller, Scheduler, Agent)