### PR TITLE
fixed proto field numbers

### DIFF
--- a/api/proto/scheduler/agent.proto
+++ b/api/proto/scheduler/agent.proto
@@ -7,8 +7,8 @@ message RegisterAgentResponse {
 }
 
 message Health {
-    int32 cpu_usage = 2;
-    int32 memory_usage = 3;
+    int32 cpu_usage = 1;
+    int32 memory_usage = 2;
 }
 
 message HealthStatus {


### PR DESCRIPTION
Fixes :
```proto
...
message Health {
    int32 cpu_usage = 2;
    int32 memory_usage = 3;
}
...
```

into:
```proto
...
message Health {
    int32 cpu_usage = 1;
    int32 memory_usage = 2;
}
...
```

This was a mistake caused by a logic error, due to the fact that the `Health` message is used in the `HealthStatus` message as its second field.
However, as stated in the protobuff documentation, message fields are independant from other messages (and, as a counter-example, `Health` could also be used as the third field of another message, breaking the logic).

Link to doc :
https://protobuf.dev/programming-guides/proto3/#assigning
citing:
> The given number must be unique among all fields for that message.

Also see the following: https://protobuf.dev/programming-guides/proto3/#other