### PR TITLE
[scheduler/agent.proto] Modified interface types and names for IDs and CPU/Memory!

### DIFF
--- a/api/proto/scheduler/agent.proto
+++ b/api/proto/scheduler/agent.proto
@@ -3,16 +3,16 @@ syntax = "proto3";
 package scheduler;
 
 message RegisterAgentResponse {
-    string id = 1;
+    uint32 id = 1;
 }
 
 message Health {
-    int32 cpu_usage = 1;
-    int32 memory_usage = 2;
+    uint32 cpu_usage = 1;
+    uint32 memory_usage = 2;
 }
 
 message HealthStatus {
-    string agent_id = 1;
+    uint32 agent_id = 1;
     Health health = 2;
 }
 

--- a/api/proto/scheduler/agent.proto
+++ b/api/proto/scheduler/agent.proto
@@ -7,8 +7,8 @@ message RegisterAgentResponse {
 }
 
 message Health {
-    uint32 cpu_usage = 1;
-    uint32 memory_usage = 2;
+    uint32 cpu_avail = 1;
+    uint32 memory_avail = 2;
 }
 
 message HealthStatus {


### PR DESCRIPTION
>NOT retrocompatible

Modified interface types for IDs and CPU/Memory!

IDs are now uint, were string

CPU and Memory are now uint, were int

Also, names went from
- cpu_usage
- memory_usage

to 
- cpu_avail
- memory_avail

to better reflect the values