### PR TITLE
feat(proto)!: breaking change - added missing messages and fixed types

### DIFF
--- a/api/proto/agent/actions.proto
+++ b/api/proto/agent/actions.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+//package scheduler.actions; Using sub-packages will be a better/cleaner idea
 package actions;
 
 enum RunnerType {
@@ -12,7 +13,7 @@ message ExecutionContext {
 }
 
 message ActionRequest {
-    string action_id = 1;
+    uint32 action_id = 1;
     ExecutionContext context = 2;
     repeated string commands = 3;
 }
@@ -30,7 +31,7 @@ message ActionResult {
 }
 
 message ActionResponseStream {
-    string action_id = 1;
+    uint32 action_id = 1;
     string log = 2;
     ActionResult result = 3;
 }

--- a/api/proto/scheduler/agent.proto
+++ b/api/proto/scheduler/agent.proto
@@ -1,9 +1,20 @@
 syntax = "proto3";
 
+//package scheduler.agent; Using sub-packages will be a better/cleaner idea
 package scheduler;
+
+message RegisterAgentRequest {
+    Health health = 1;
+    Hostname hostname = 2;
+}
 
 message RegisterAgentResponse {
     uint32 id = 1;
+}
+
+message Hostname {
+    string host = 1;
+    uint32 port = 2;
 }
 
 message Health {
@@ -19,6 +30,6 @@ message HealthStatus {
 message Empty {}
 
 service Agent {
-    rpc RegisterAgent (Health) returns (RegisterAgentResponse);
+    rpc RegisterAgent (RegisterAgentRequest) returns (RegisterAgentResponse);
     rpc ReportHealthStatus (stream HealthStatus) returns (Empty);
 }

--- a/api/proto/scheduler/controller.proto
+++ b/api/proto/scheduler/controller.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+//package scheduler.controller; Using sub-packages will be a better/cleaner idea
 package scheduler;
 
 enum RunnerType {
@@ -12,7 +13,7 @@ message ExecutionContext {
 }
 
 message ActionRequest {
-    string action_id = 1;
+    uint32 action_id = 1;
     ExecutionContext context = 2;
     repeated string commands = 3;
 }
@@ -31,7 +32,7 @@ message ActionResult {
 }
 
 message ActionResponse {
-    string action_id = 1;
+    uint32 action_id = 1;
     string log = 2;
     ActionResult result = 3;
 }


### PR DESCRIPTION
This PR concerns the Agent and Scheduler groups;

It adds the changes made by @benoit-planche (adding missing Hostname message)

Plus action_id type fix (from string to uint32)


A version of the scheduler that implements these exact Protos is already up.


---
### Before approving/merging

Which package style to use? I suggest sub-packaging (see comments: scheduler.actions; scheduler.controller, etc.) as it is the cleaner way to go, and packs relevant protos together, which is good for understanding the protos and for later updates.

It also makes which protos are used in the code cleaner, as protos can them be accessed by their subpackages, so every bit of code doesn't import the *whole* code generated by the protobuf compiler.
