### PR TITLE
Setup repo when receiving an action

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-build",
+ "url",
 ]
 
 [[package]]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -18,6 +18,7 @@ serde = "1.0.208"
 env_logger = "0.11.5"
 log = "0.4.22"
 clap = { version = "4.5.16", features = ["derive"] }
+url = "2.5.2"
 
 [build-dependencies]
 tonic-build = "0.12.0"

--- a/agent/src/action.rs
+++ b/agent/src/action.rs
@@ -8,6 +8,7 @@ use futures_util::StreamExt;
 use log::info;
 use tokio::{spawn, sync::mpsc::UnboundedSender, time::sleep};
 use tonic::Status;
+use url::Url;
 
 use crate::{
     container::{
@@ -21,7 +22,9 @@ pub async fn launch_action(
     commands: &mut Vec<String>,
     log_input: Arc<Mutex<UnboundedSender<Result<ActionResponseStream, Status>>>>,
     action_id: Arc<Mutex<u32>>,
+    repo_url: String,
 ) -> Result<(), Status> {
+    // TODO: treat repo url to get the name of the repo
     let _ = log_input.lock().unwrap().send(Ok(ActionResponseStream {
         log: "Launching action".to_string(),
         action_id: *action_id.lock().unwrap(),
@@ -33,7 +36,7 @@ pub async fn launch_action(
 
     let container_id: String = match launch_container(&image_name).await {
         Ok(id) => id,
-        Err(e) => return Err(Status::aborted(format!("Launching error{}", e))),
+        Err(e) => return Err(Status::aborted(format!("Launching error: {}", e))),
     };
 
     let _ = log_input.lock().unwrap().send(Ok(ActionResponseStream {
@@ -45,14 +48,47 @@ pub async fn launch_action(
         }),
     }));
 
+    let repo_name = setup_repository(repo_url, container_id.as_str()).await?;
+
+    let _ = log_input.lock().unwrap().send(Ok(ActionResponseStream {
+        log: "Repository cloned".to_string(),
+        action_id: *action_id.lock().unwrap(),
+        result: Some(ActionResult {
+            completion: 1,
+            exit_code: None,
+        }),
+    }));
+
     for command in &mut *commands {
         let log_input = Arc::clone(&log_input);
         let action_id = Arc::clone(&action_id);
-        let exec_id = start_command(command, &container_id, log_input, action_id).await?;
+        // TODO: add repo_name
+        let exec_id = start_command(
+            command,
+            &container_id,
+            log_input,
+            action_id,
+            Some(repo_name.clone()),
+        )
+        .await?;
         wait_for_command(exec_id).await?;
     }
     clean_action(container_id.as_str()).await?;
     Ok(())
+}
+
+pub async fn setup_repository(repo_url: String, container_id: &str) -> Result<String, Status> {
+    let setup_command = format!("git clone {}", repo_url);
+    let exec_id = match create_exec(&setup_command, container_id, None).await {
+        Ok(CreateExecResults { id }) => id,
+        Err(_) => return Err(Status::aborted("Error happened when creating exec")),
+    };
+    wait_for_command(exec_id).await?;
+    let repo_name = match get_repo_name(&repo_url) {
+        Some(repo_name) => Ok(repo_name),
+        None => Err(Status::aborted("Error happened when getting repo name")),
+    };
+    repo_name
 }
 
 pub async fn start_command(
@@ -60,59 +96,42 @@ pub async fn start_command(
     container_id: &str,
     log_input: Arc<Mutex<UnboundedSender<Result<ActionResponseStream, Status>>>>,
     action_id: Arc<Mutex<u32>>,
+    repo_name: Option<String>,
 ) -> Result<String, Status> {
-    let exec_id = match create_exec(&command.to_string(), container_id).await {
-        Ok(CreateExecResults { id }) => {
-            let _ = log_input.lock().unwrap().send(Ok(ActionResponseStream {
-                log: command.clone(),
+    let exec_id = match create_exec(&command.to_string(), container_id, repo_name).await {
+        Ok(CreateExecResults { id }) => id,
+        Err(_) => return Err(Status::aborted("Error happened when creating exec")),
+    };
+    let _ = log_input.lock().unwrap().send(Ok(ActionResponseStream {
+        log: command.clone(),
+        action_id: *action_id.lock().unwrap(),
+        result: Some(ActionResult {
+            completion: 2,
+            exit_code: None,
+        }),
+    }));
+    let mut container_ouput = match start_exec(&exec_id).await {
+        Ok(StartExecResults::Attached { output, input: _ }) => output,
+        Ok(StartExecResults::Detached) => return Err(Status::aborted("Can't attach to container")),
+        Err(_) => return Err(Status::aborted("Error happened when launching action")),
+    };
+    spawn(async move {
+        while let Some(log) = container_ouput.next().await {
+            let container_log_output = match log {
+                Ok(log_output) => log_output,
+                Err(e) => return Err(Status::aborted(format!("Execution error: {}", e))),
+            };
+            let _ = &log_input.lock().unwrap().send(Ok(ActionResponseStream {
+                log: container_log_output.to_string(),
                 action_id: *action_id.lock().unwrap(),
                 result: Some(ActionResult {
                     completion: 2,
                     exit_code: None,
                 }),
             }));
-            id
         }
-        Err(_) => return Err(Status::aborted("Error happened when creating exec")),
-    };
-
-    match start_exec(&exec_id).await {
-        Ok(StartExecResults::Attached {
-            mut output,
-            input: _,
-        }) => {
-            spawn(async move {
-                while let Some(log) = output.next().await {
-                    match log {
-                        Ok(log_output) => {
-                            let _ = &log_input.lock().unwrap().send(Ok(ActionResponseStream {
-                                log: log_output.to_string(),
-                                action_id: *action_id.lock().unwrap(),
-                                result: Some(ActionResult {
-                                    completion: 2,
-                                    exit_code: None,
-                                }),
-                            }));
-                        }
-                        Err(e) => {
-                            let _ = log_input.lock().unwrap().send(Ok(ActionResponseStream {
-                                log: "Step exited with an error".to_string(),
-                                action_id: *action_id.lock().unwrap(),
-                                result: Some(ActionResult {
-                                    completion: 3,
-                                    exit_code: Some(1),
-                                }),
-                            }));
-                            return Err(Status::aborted(format!("Execution error: {}", e)));
-                        }
-                    }
-                }
-                Ok(())
-            });
-        }
-        Ok(StartExecResults::Detached) => return Err(Status::aborted("Can't attach to container")),
-        Err(_) => return Err(Status::aborted("Error happened when launching action")),
-    }
+        Ok(())
+    });
     Ok(exec_id)
 }
 
@@ -160,4 +179,10 @@ pub async fn clean_action(container_id: &str) -> Result<(), Status> {
         Err(_) => return Err(Status::aborted("Error happened when stopping container")),
     };
     Ok(())
+}
+
+fn get_repo_name(github_url: &str) -> Option<String> {
+    let url = Url::parse(github_url).ok()?;
+    let segments: Vec<&str> = url.path_segments()?.collect();
+    segments.last().map(|s| s.to_string())
 }

--- a/agent/src/container.rs
+++ b/agent/src/container.rs
@@ -71,6 +71,7 @@ pub async fn remove_container(container_id: &str) -> Result<(), bollard::errors:
 pub async fn create_exec(
     command: &str,
     container_id: &str,
+    workdir: Option<String>,
 ) -> Result<CreateExecResults, bollard::errors::Error> {
     dockerLocal
         .create_exec(
@@ -81,7 +82,7 @@ pub async fn create_exec(
                 attach_stdin: Some(true),
                 attach_stdout: Some(true),
                 attach_stderr: Some(true),
-                
+                working_dir: workdir,
                 ..Default::default()
             },
         )

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -30,6 +30,7 @@ impl ActionService for ActionsLauncher {
             Some(container_image) => container_image,
             None => return Err(Status::invalid_argument("Container image is missing")),
         };
+
         let log_input = Arc::new(Mutex::new(log_input));
         let action_id = Arc::new(Mutex::new(request_body.action_id));
         tokio::spawn(async move {
@@ -38,6 +39,7 @@ impl ActionService for ActionsLauncher {
                 &mut request_body.commands,
                 log_input.clone(),
                 action_id.clone(),
+                request_body.repo_url,
             )
             .await
             .map_err(|e| Status::aborted(format!("Launching error {}", e)));


### PR DESCRIPTION
When an action is executed we need to setup the repo in the container. It implies: 
- cloning the repo in the container
- then setting the workdir as the freshly clone repo