### PR TITLE
Build and release project

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,20 @@
+name: Release Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: rust:1.81.0-slim
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install rust deb
+        run: cargo install cargo-deb
+
+      - name: Build agent project
+        run: cd agent && cargo deb

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release Workflow
 on:
   push:
     branches:
-      - main
+      - feat/agent-to-deb
 
 jobs:
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: rust:1.81.0-slim
+    runs-on: rust:1.67
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Create a ci and define tools we are going to  use to release the project. For the moment we agreed to build deb as all our infrastructures is debian based.
To accomplish that we will use cargo-deb 