### PR TITLE
fix(agent): handling errors from container

### DIFF
--- a/web-client/src/pages/pipeline.tsx
+++ b/web-client/src/pages/pipeline.tsx
@@ -49,9 +49,9 @@ export default function PipelinePage() {
                     <p className="font-mono text-2xl">{action.name}</p>
                   </span>
                   {action.status === "ACTION_STATUS_COMPLETED" ? (
-                    <span className="bg-success w-3 h-3 rounded-full">✔</span>
+                    <span className="bg-success w-3 h-3 rounded-full"></span>
                   ) : action.status === "ACTION_STATUS_ERROR" ? (
-                    <span className="bg-error w-3 h-3 rounded-full">✖</span>
+                    <span className="bg-error w-3 h-3 rounded-full"></span>
                   ) : (
                     <span className="bg-warning w-3 h-3 rounded-full"></span>
                   )}


### PR DESCRIPTION
Sending container error to scheduler from agent so it can be sent correctly to the controller. Also, modified error mapping on the scheduler because it wasn't taking into account the `exit code` of a command before.