### PR TITLE
Docs/release agent

### DIFF
--- a/api/proto/release-agent/controller.proto
+++ b/api/proto/release-agent/controller.proto
@@ -1,0 +1,33 @@
+message CreateReleaseRequest {
+    string repo_url =1;
+    string revision = 2;
+}
+
+enum CreateReleaseStatus {
+    SUCCESS = 0;
+    FAILURE = 1;
+}
+
+message CreateReleaseResponse {
+    CreateReleaseStatus status = 1;
+    string release_id = 2;
+}
+
+message PublicKey {
+    string key_id = 1;
+    string key_data = 2;
+}
+
+message RollPGPKeysRequest {
+    string algorithm = 1;
+}
+
+message GetPublicKeyRequest {
+    string key_id = 1;
+}
+
+service Controller {
+    rpc CreateRelease(CreateReleaseRequest) returns (CreateReleaseResponse);
+    rpc RollPGPKeys (RollPGPKeysRequest) returns (PublicKey);
+    rpc GetPublicKey(GetPublicKeyRequest) returns (PublicKey);
+}

--- a/api/proto/release-agent/controller.proto
+++ b/api/proto/release-agent/controller.proto
@@ -1,3 +1,9 @@
+syntax = "proto3";
+
+package sealci.releaseagent;
+
+import "google/protobuf/empty.proto";
+
 message CreateReleaseRequest {
     string repo_url =1;
     string revision = 2;
@@ -22,12 +28,9 @@ message RollPGPKeysRequest {
     string algorithm = 1;
 }
 
-message GetPublicKeyRequest {
-    string key_id = 1;
-}
 
 service Controller {
     rpc CreateRelease(CreateReleaseRequest) returns (CreateReleaseResponse);
     rpc RollPGPKeys (RollPGPKeysRequest) returns (PublicKey);
-    rpc GetPublicKey(GetPublicKeyRequest) returns (PublicKey);
+    rpc GetPublicKey(google.protobuf.Empty) returns (PublicKey);
 }

--- a/api/proto/scheduler/controller.proto
+++ b/api/proto/scheduler/controller.proto
@@ -1,6 +1,3 @@
-syntax = "proto3";
-
-//package scheduler.controller; Using sub-packages will be a better/cleaner idea
 package scheduler;
 
 enum RunnerType {

--- a/docs/arch/release-agent.md
+++ b/docs/arch/release-agent.md
@@ -31,22 +31,23 @@ sequenceDiagram
 
 ## Keys Management
 
-The keys are stored in the VM Memory
+We chose to sign the releases with a PGP key to keep our plateform simple and as decentralized as possible. People using SealCI must thus be trustful of the release agent.
 
-## API
+When the release agent is created it already contains a PGP key pair set by default. The key pair is provided at the generation of the initramfs when we are in a production environment. In a development environment, the key pair is generated on the fly.
 
-Here are all the gRPC interfaces
-```protobuf
-syntax = "proto3";
+There should be at least two interactions between the release agent and the controller when it comes to key management.
+- **GetPublicKey** : The controller asks the release agent for the public key so the user can verify the signature of the release.
+- **RollPGPKeys** : The controller asks the release agent to roll the PGP keys used to sign the releases because the keys should be rotated regularly and a PGP key can be compromise. In that scenario, the release agent should also issue a key denial certificate so users are aware of the compromise.
 
-package releaseagent;
+```mermaid
+sequenceDiagram
+    participant Controller
+    participant ReleaseAgent
 
-message ReleaseRequest {
-    string url = 1;
-    string tag = 2;
-}
+    Controller->>ReleaseAgent: GetPublickKey
+    ReleaseAgent->>Controller: PGP Public Key
 
-message ReleaseResponse {
-    bytes release = 1;
-}
+    Controller->>ReleaseAgent: RollPGPKeys
+    ReleaseAgent->>ReleaseAgent: Deny current key pair and generate new key pair
+    ReleaseAgent->>Controller: PGP Public Key
 ```

--- a/docs/arch/release-agent.md
+++ b/docs/arch/release-agent.md
@@ -2,14 +2,14 @@
 
 ## Glossary
 
-- **release** : A release is an archive ".git.tgz.sig" containing the source code of a project and its signature. The release is signed by the release agent using a private certificates. The public key is used to verify the signature.
+- **release** : A release is an archive ".git.tgz.sig" containing the source code of a project and its signature. The release is signed by the release agent using a private key. The public key is used to verify the signature. These keys make a pair of PGP keys.
 - **release agent** : The release agent is a component that is responsible for creating and signing releases.
 
 
 ## Description
 
 The release agent is a component that is responsible for creating and signing releases for any project. The release agent is designed to be used in a CI/CD pipeline.
-When a watched repository contains a new tag, the controller triggers the release agent to create a release for the repository. Of course, the release agent is totally independent from the2
+When a watched repository contains a new tag, the controller triggers the release agent to create a release for the repository. Of course, the release agent is totally independent from the other services in seal ci's infrastructure.
 
 ## External Communication
 

--- a/docs/arch/release-agent.md
+++ b/docs/arch/release-agent.md
@@ -2,15 +2,16 @@
 
 ## Glossary
 
-- **release** : A release is an archive ".git.tgz.sig" containing the source code of a project and its signature. The release is signed by the release agent using a private PGP key. The public key is used to verify the signature.
+- **release** : A release is an archive ".git.tgz.sig" containing the source code of a project and its signature. The release is signed by the release agent using a private certificates. The public key is used to verify the signature.
 - **release agent** : The release agent is a component that is responsible for creating and signing releases.
 
 
-## Description
+## Description
 
 The release agent is a component that is responsible for creating and signing releases for any project. The release agent is designed to be used in a CI/CD pipeline.
+When a watched repository contains a new tag, the controller triggers the release agent to create a release for the repository. Of course, the release agent is totally independent from the2
 
-## External Communication 
+## External Communication
 
 The release agent runs inside a lumper controlled virtual machine (VM).
 The release agent communicates with the Controller with gRPC (Getting URL + Tag of the repository which needs a release).
@@ -28,13 +29,13 @@ sequenceDiagram
     ReleaseAgent->>Controller: gRPC (release)
 ```
 
-## PGP Keys Management
+## Keys Management
 
 The keys are stored in the VM Memory
 
-## API 
+## API
 
-Here are all the gRPC interfaces 
+Here are all the gRPC interfaces
 ```protobuf
 syntax = "proto3";
 


### PR DESCRIPTION
Hi team :wave: 
Here is my contribution to the documentation and interfaces of the release agent. Long story short, I added :
1. Some precisions about key management and key publication
2. A sequence diagram about public key publication, key generation and key deny
3. The proto interfaces between the controller and the release agent

If merged this will close #88

On a side note, I think that we shouldn't care too much about virtio-net in our design document since network management must be transparent/magic to our point of view.
