### PR TITLE
feat:spread error correctly & use pathbuf for git repos

### DIFF
--- a/release-agent/src/bin/main.rs
+++ b/release-agent/src/bin/main.rs
@@ -1,5 +1,9 @@
 use clap::Parser;
-use sealci_release_agent::{app::AppConfig, core, grpc::{release_agent_grpc::release_agent_server::ReleaseAgent, ReleaseAgentService}};
+use sealci_release_agent::{
+    app::AppConfig,
+    core::{self, ReleaseAgentError},
+    grpc::{ReleaseAgentService, release_agent_grpc::release_agent_server::ReleaseAgent},
+};
 
 #[derive(Debug, Parser)]
 #[clap(name = "release-agent", version)]
@@ -9,7 +13,7 @@ struct Config {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), ReleaseAgentError> {
     let config = Config::parse();
     tracing_subscriber::fmt().init();
 

--- a/release-agent/src/lib/bucket/mod.rs
+++ b/release-agent/src/lib/bucket/mod.rs
@@ -1,16 +1,17 @@
 mod minio;
 use tonic::async_trait;
 
-use std::error::Error;
 use std::fs::File;
+
+use crate::core::ReleaseAgentError;
 
 #[async_trait]
 pub trait BucketClient: Clone + Send + Sync {
     // release is a string of the form "v1.2.3" that is the release name
     // the file is a tar.gz file containing the source code as a gzipped tarball and a .sig file
     // that is a signature of the tarball
-    async fn put_release(&self, release: &str, file: File) -> Result<(), Box<dyn Error>>;
+    async fn put_release(&self, release: &str, file: File) -> Result<(), ReleaseAgentError>;
     // public_key is a string containing the public key that is used to verify the signature of the
     // release
-    async fn put_public_key(&self, public_key: &str) -> Result<(), Box<dyn Error>>;
+    async fn put_public_key(&self, public_key: &str) -> Result<(), ReleaseAgentError>;
 }

--- a/release-agent/src/lib/compress.rs
+++ b/release-agent/src/lib/compress.rs
@@ -1,10 +1,11 @@
-use std::error::Error;
+use std::{fs::File, path::PathBuf};
 use tonic::async_trait;
-use std::fs::File;
+
+use crate::core::ReleaseAgentError;
 
 #[async_trait]
 pub trait CompressClient: Clone + Send + Sync {
     // path is a string containing the path to the folder that contains the codebase to be compressed
     // the File object returned contains the compressed codebase
-    async fn compress(&self, path: String) -> Result<File, Box<dyn Error>>;
+    async fn compress(&self, path: PathBuf) -> Result<File, ReleaseAgentError>;
 }

--- a/release-agent/src/lib/core.rs
+++ b/release-agent/src/lib/core.rs
@@ -1,29 +1,38 @@
-use crate::{sign::ReleaseSigner, bucket::BucketClient, compress::CompressClient, git::GitClient};
-use tracing::error;
+use crate::{bucket::BucketClient, compress::CompressClient, git::GitClient, sign::ReleaseSigner};
 use tonic::async_trait;
+use tracing::error;
 
 #[async_trait]
-pub trait ReleaseAgentCore : Clone + Send + Sync {
+pub trait ReleaseAgentCore: Clone + Send + Sync {
     async fn create_release(&self, release_id: &str) -> Result<String, ReleaseAgentError>;
 }
 
-pub struct ReleaseAgent<S: ReleaseSigner, B: BucketClient, G: GitClient , C: CompressClient> {
+pub struct ReleaseAgent<S: ReleaseSigner, B: BucketClient, G: GitClient, C: CompressClient> {
     pub signer: S,
     pub bucket: B,
     pub git_client: G,
     pub compress_client: C,
 }
 
-impl<S: ReleaseSigner, B: BucketClient, G: GitClient , C: CompressClient> ReleaseAgent<S, B, G, C> {
+impl<S: ReleaseSigner, B: BucketClient, G: GitClient, C: CompressClient> ReleaseAgent<S, B, G, C> {
     pub fn new(signer: S, bucket: B, git_client: G, compress_client: C) -> Self {
-        Self { signer, bucket, git_client , compress_client }
+        Self {
+            signer,
+            bucket,
+            git_client,
+            compress_client,
+        }
     }
 
     pub async fn create_release(&self, release_id: &str) -> Result<String, ReleaseAgentError> {
-        let codebase = self.git_client.download_release(release_id).await.map_err(|e| {
-            error!("Error downloading release: {}", e);
-            ReleaseAgentError::GitRepositoryNotFound
-        })?;
+        let codebase = self
+            .git_client
+            .download_release(release_id)
+            .await
+            .map_err(|e| {
+                error!("Error downloading release: {}", e);
+                ReleaseAgentError::GitRepositoryNotFound
+            })?;
         let compressed_codebase = self.compress_client.compress(codebase).await.map_err(|e| {
             error!("Error compressing release: {}", e);
             ReleaseAgentError::CompressionError
@@ -32,21 +41,26 @@ impl<S: ReleaseSigner, B: BucketClient, G: GitClient , C: CompressClient> Releas
             error!("Error signing release: {}", e);
             ReleaseAgentError::SigningError
         })?;
-        self.bucket.put_release(release_id, signed_codebase).await.map_err(|e| {
-            error!("Error uploading release: {}", e);
-            ReleaseAgentError::BucketNotAvailable
-        })?;
+        self.bucket
+            .put_release(release_id, signed_codebase)
+            .await
+            .map_err(|e| {
+                error!("Error uploading release: {}", e);
+                ReleaseAgentError::BucketNotAvailable
+            })?;
 
         Ok(release_id.to_string())
     }
 }
 
+#[derive(Debug)]
 pub enum ReleaseAgentError {
     BucketNotAvailable,
     GitRepositoryNotFound,
     CompressionError,
     SigningError,
-    // add more errors here
+    ConfigError,
+    TransportError(tonic::transport::Error), // add more errors here
 }
 
 impl std::fmt::Display for ReleaseAgentError {
@@ -56,6 +70,8 @@ impl std::fmt::Display for ReleaseAgentError {
             Self::GitRepositoryNotFound => write!(f, "Git repository not found"),
             Self::CompressionError => write!(f, "Compression error"),
             Self::SigningError => write!(f, "Signing error"),
+            ReleaseAgentError::ConfigError => write!(f, "Configuration error on startup"),
+            ReleaseAgentError::TransportError(error) => write!(f, "Transport error: {}", error),
         }
     }
 }

--- a/release-agent/src/lib/git.rs
+++ b/release-agent/src/lib/git.rs
@@ -1,10 +1,12 @@
-use std::error::Error;
+use std::path::PathBuf;
+
 use tonic::async_trait;
+
+use crate::core::ReleaseAgentError;
 
 #[async_trait]
 pub trait GitClient: Clone + Send + Sync {
     // revision is a string of the form "v1.2.3" that is the release name, it returns the path to
     // the folder that contains the codebase
-    async fn download_release(&self, revision: &str) -> Result<String, Box<dyn Error>>;
+    async fn download_release(&self, revision: &str) -> Result<PathBuf, ReleaseAgentError>;
 }
-

--- a/release-agent/src/lib/sign.rs
+++ b/release-agent/src/lib/sign.rs
@@ -1,6 +1,7 @@
-use std::error::Error;
-use tonic::async_trait;
 use std::fs::File;
+use tonic::async_trait;
+
+use crate::core::ReleaseAgentError;
 
 ///! A trait for signing releases.
 /// This trait is used to sign a release archive, such as a tarball or zip file,
@@ -8,5 +9,5 @@ use std::fs::File;
 /// The private key is used to sign the archive.
 #[async_trait]
 pub trait ReleaseSigner: Clone + Send + Sync {
-    fn sign_release(&self, compressed_archived: File) -> Result<File, Box<dyn Error>>;
+    fn sign_release(&self, compressed_archived: File) -> Result<File, ReleaseAgentError>;
 }


### PR DESCRIPTION
# Description

Using the error enum inside all the application. 
Use a pathbu instead of a string for the git repository path.