### PR TITLE
refactor(dumplet): output initramfs file with dumplet as a library

### DIFF
--- a/dumplet/Cargo.lock
+++ b/dumplet/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "clap",
  "futures-util",
  "tar",
+ "tempfile",
  "tokio",
 ]
 
@@ -298,6 +299,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filetime"
@@ -376,6 +383,18 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -797,7 +816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -901,6 +920,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "redox_syscall"
@@ -1106,6 +1131,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,6 +1328,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,6 +1512,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "write16"

--- a/dumplet/Cargo.toml
+++ b/dumplet/Cargo.toml
@@ -17,3 +17,4 @@ tokio = { version = "1", features = ["full"] }
 tar = "0.4"
 futures-util = "0.3.31"
 clap = { version = "4.5", features = ["derive"] }
+tempfile = "3"

--- a/dumplet/README.md
+++ b/dumplet/README.md
@@ -4,22 +4,36 @@
 
 ---
 
-## **✨ Features**
-✅ Pulls a **Docker image** (always forced for now).  
-✅ Creates a **temporary container** _(without running it)_.  
-✅ Exports the **container's filesystem** as a `.tar` archive.  
-✅ **Compresses** the tar file to `.tar.gz` format.  
-✅ Extracts the filesystem and builds a compressed **initramfs image** (`.img` file).  
-✅ **Automatically removes** the container after extraction.  
-✅ **Organizes all outputs** in a structured directory for easy access.  
-✅ Simple and straightforward to use via the **command line interface (CLI)**.
-
----
-
-## **📦 Installation**
+## **Installation**
 ### **Prerequisites**
 - **Docker** must be [installed and running](https://docs.docker.com/get-docker/) on your system.
 - **Rust** & **Cargo** [installed](https://rustup.rs/)
+
+### **Using Dumplet as a Library**
+You can **directly use Dumplet in your Rust project**!
+
+1. In your `Cargo.toml`, add:
+   ```toml
+   [dependencies]
+   dumplet = { path = "../dumplet" }
+   ```
+
+2. In your Rust code, use Dumplet's API:
+   ```rust
+   use dumplet::generate_initramfs_image;
+   use std::fs::File;
+   
+   #[tokio::main]
+   async fn main() -> Result<(), Box<dyn std::error::Error>> {
+       let image_name = "alpine:3.14";
+       let mut initramfs_file: File = generate_initramfs_image(image_name).await?;
+       // You can now read or process `initramfs_file` as needed
+       Ok(())
+   }
+   ```
+
+Dumplet will automatically create a temporary directory, export the filesystem of the image, and return a `File` containing the final `initramfs.img`. No need to specify output paths – it's fully managed for you!
+
 
 ### **Using Dumplet CLI**
 1. Clone the repository:
@@ -42,8 +56,8 @@
 
 ---
 
-## **📂 Output Example**
-After running the example above, you'll get a structured directory containing all build artifacts:
+## CLI Output Example
+When using the CLI, you’ll get a structured directory:
 ```sh
 /tmp/ubuntu-build/
 ├── rootfs.tar          # Original filesystem tar archive
@@ -59,7 +73,7 @@ The **initramfs.img** file can be used directly in your bootloader or kernel con
 
 ---
 
-## **👨‍💻 Contributing**
+## **Contributing**
 Want to contribute? Feel free to **open an issue or a pull request**!  
 To run the project locally:
 ```sh

--- a/dumplet/examples/docker_to_img.rs
+++ b/dumplet/examples/docker_to_img.rs
@@ -1,0 +1,10 @@
+use dumplet::generate_initramfs_image;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let image = "ubuntu"; // Replace with your Docker image name
+
+    let bundle = generate_initramfs_image(image).await?;
+    println!("Bundle created successfully: {:?}", bundle);
+    Ok(())
+}

--- a/dumplet/src/docker.rs
+++ b/dumplet/src/docker.rs
@@ -1,17 +1,18 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
 use bollard::Docker;
 use bollard::image::CreateImageOptions;
 use bollard::models::HostConfig;
 use futures_util::stream::StreamExt;
-use std::fs::File;
-use std::io::Write;
-use std::path::Path;
+
 use crate::errors::DumpletError;
 
-pub async fn export_docker_image(image_name: &str, output_path: &str) -> Result<(), DumpletError> {
+pub async fn export_docker_image(image_name: &str, output_path: &Path) -> Result<(), DumpletError> {
     let docker = Docker::connect_with_local_defaults()?;
-
-    // Pull the image
     println!("🔹 Pulling image {}...", image_name);
+
     let options = Some(CreateImageOptions {
         from_image: image_name,
         ..Default::default()
@@ -20,30 +21,23 @@ pub async fn export_docker_image(image_name: &str, output_path: &str) -> Result<
     let mut stream = docker.create_image(options, None, None);
     while let Some(_) = stream.next().await {}
 
-    // Create a temporary container
     let container_config = bollard::container::Config {
         image: Some(image_name),
-        host_config: Some(HostConfig {
-            auto_remove: Some(true),
-            ..Default::default()
-        }),
+        host_config: Some(HostConfig { auto_remove: Some(true), ..Default::default() }),
         ..Default::default()
     };
 
     let container = docker.create_container::<String, _>(None, container_config).await?;
     let container_id = container.id;
 
-    // Export filesystem to TAR
     let export_stream = docker.export_container(&container_id);
-
-    let path = Path::new(output_path);
-    let mut file = File::create(&path)?;
+    let mut file = File::create(output_path)?;
     let mut stream = export_stream;
 
     while let Some(Ok(chunk)) = stream.next().await {
         file.write_all(&chunk)?;
     }
 
-    println!("🔹 Export completed: {}", output_path);
+    println!("🔹 Export completed: {:?}", output_path);
     Ok(())
 }

--- a/dumplet/src/errors.rs
+++ b/dumplet/src/errors.rs
@@ -15,7 +15,8 @@ impl fmt::Display for DumpletError {
     }
 }
 
-// Implement the `From` trait for the `DumpletError` type
+impl std::error::Error for DumpletError {}
+
 impl From<bollard::errors::Error> for DumpletError {
     fn from(err: bollard::errors::Error) -> Self {
         DumpletError::DockerError(err)

--- a/dumplet/src/lib.rs
+++ b/dumplet/src/lib.rs
@@ -1,7 +1,54 @@
+pub mod errors;
 mod docker;
+mod tar_utils;
 mod initramfs;
-mod errors;
 
-pub use docker::export_docker_image;
-pub use initramfs::create_initramfs;
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+use tempfile::tempdir;
+
 pub use errors::DumpletError;
+use docker::export_docker_image;
+use tar_utils::{compress_tar, extract_tar};
+use initramfs::create_initramfs;
+
+#[derive(Debug)]
+pub struct DumpletBundle {
+    pub rootfs_tar: PathBuf,
+    pub rootfs_tar_gz: PathBuf,
+    pub extract_dir: PathBuf,
+    pub initramfs_img: PathBuf,
+}
+
+pub async fn generate_initramfs_bundle(image: &str, output_dir: &str) -> Result<DumpletBundle, DumpletError> {
+    let output_path = Path::new(output_dir);
+    fs::create_dir_all(output_path)?;
+
+    let rootfs_tar = output_path.join("rootfs.tar");
+    let rootfs_tar_gz = output_path.join("rootfs.tar.gz");
+    let extract_dir = output_path.join("rootfs-content");
+    let initramfs_img = output_path.join("initramfs.img");
+
+    export_docker_image(image, &rootfs_tar).await?;
+    compress_tar(&rootfs_tar, &rootfs_tar_gz)?;
+    extract_tar(&rootfs_tar, &extract_dir)?;
+    create_initramfs(&extract_dir, &initramfs_img)?;
+
+    Ok(DumpletBundle {
+        rootfs_tar,
+        rootfs_tar_gz,
+        extract_dir,
+        initramfs_img,
+    })
+}
+
+pub async fn generate_initramfs_image(image: &str) -> Result<File, DumpletError> {
+    let temp_dir = tempdir()?;
+    let temp_path = temp_dir.path();
+
+    let bundle = generate_initramfs_bundle(image, temp_path.to_str().unwrap()).await?;
+    let file = File::open(&bundle.initramfs_img)?;
+
+    println!("🔹 Generated initramfs.img file: {:?}", bundle.initramfs_img);
+    Ok(file)
+}

--- a/dumplet/src/main.rs
+++ b/dumplet/src/main.rs
@@ -1,17 +1,13 @@
 use clap::Parser;
-use dumplet::{export_docker_image, create_initramfs, DumpletError};
-use std::process::Command;
-use std::path::Path;
+use dumplet::{generate_initramfs_bundle, DumpletError};
 
 /// Dumplet CLI: Export a Docker image and create an initramfs image.
 #[derive(Parser, Debug)]
 #[command(author, version, about = "Export a Docker image and create an initramfs image", long_about = None)]
 struct Args {
-    /// Docker image name (e.g. alpine:3.14)
     #[arg(help = "Docker image name (e.g. alpine:3.14)")]
     image: String,
 
-    /// Path for the output directory containing tar.gz, extracted content, and .img file
     #[arg(help = "Path for the output directory")]
     output_dir: String,
 }
@@ -27,59 +23,14 @@ async fn main() {
 }
 
 async fn run(args: &Args) -> Result<(), DumpletError> {
-    // Create output directory
-    let output_path = Path::new(&args.output_dir);
-    std::fs::create_dir_all(output_path)?;
+    let bundle = generate_initramfs_bundle(&args.image, &args.output_dir).await?;
 
-    // Define paths within the output directory
-    let rootfs_tar = output_path.join("rootfs.tar");
-    let rootfs_tar_gz = output_path.join("rootfs.tar.gz");
-    let extract_dir = output_path.join("rootfs-content");
-    let initramfs_img = output_path.join("initramfs.img");
-
-    // Export Docker image filesystem to a tar file
-    println!("🔹 Exporting Docker image `{}` to {:?}", args.image, rootfs_tar);
-    export_docker_image(&args.image, rootfs_tar.to_str().unwrap()).await?;
-
-    // Compress the tar file to tar.gz
-    println!("🔹 Compressing tar file to {:?}", rootfs_tar_gz);
-    let status = Command::new("gzip")
-        .args(["-c", rootfs_tar.to_str().unwrap()])
-        .output()?;
-
-    if !status.status.success() {
-        return Err(DumpletError::IoError(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Failed to compress tar file",
-        )));
-    }
-
-    std::fs::write(&rootfs_tar_gz, status.stdout)?;
-
-    // Extract tar to the content directory
-    std::fs::create_dir_all(&extract_dir)?;
-    println!("🔹 Extracting rootfs tar to {:?}", extract_dir);
-    let status = Command::new("tar")
-        .args(["xf", rootfs_tar.to_str().unwrap(), "-C", extract_dir.to_str().unwrap()])
-        .status()?;
-    if !status.success() {
-        return Err(DumpletError::IoError(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Failed to extract rootfs",
-        )));
-    }
-
-    // Create the initramfs image
-    println!("🔹 Creating initramfs image at {:?}", initramfs_img);
-    create_initramfs(extract_dir.to_str().unwrap(), initramfs_img.to_str().unwrap())?;
-
-    // Summary
-    println!("✅ Build completed successfully!");
-    println!("📁 Output directory: {}", args.output_dir);
-    println!("   ├── rootfs.tar (original tar file)");
-    println!("   ├── rootfs.tar.gz (compressed tar file)");
-    println!("   ├── rootfs-content/ (extracted filesystem)");
-    println!("   └── initramfs.img (final initramfs image)");
+    println!("🔹 Build completed successfully!");
+    println!("🔹 Output directory: {}", args.output_dir);
+    println!("   ├── {}", bundle.rootfs_tar.display());
+    println!("   ├── {}", bundle.rootfs_tar_gz.display());
+    println!("   ├── {}", bundle.extract_dir.display());
+    println!("   └── {}", bundle.initramfs_img.display());
 
     Ok(())
 }

--- a/dumplet/src/tar_utils.rs
+++ b/dumplet/src/tar_utils.rs
@@ -1,0 +1,41 @@
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::process::Command;
+
+use crate::errors::DumpletError;
+
+pub fn compress_tar(tar_path: &Path, tar_gz_path: &Path) -> Result<(), DumpletError> {
+    println!("🔹 Compressing tar file to {:?}", tar_gz_path);
+
+    let output = Command::new("gzip")
+        .args(["-c", tar_path.to_str().unwrap()])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(DumpletError::IoError(io::Error::new(
+            io::ErrorKind::Other,
+            "Failed to compress tar file",
+        )));
+    }
+
+    fs::write(tar_gz_path, output.stdout)?;
+    Ok(())
+}
+
+pub fn extract_tar(tar_path: &Path, extract_dir: &Path) -> Result<(), DumpletError> {
+    fs::create_dir_all(extract_dir)?;
+    println!("🔹 Extracting rootfs to {:?}", extract_dir);
+
+    let status = Command::new("tar")
+        .args(["xf", tar_path.to_str().unwrap(), "-C", extract_dir.to_str().unwrap()])
+        .status()?;
+
+    if !status.success() {
+        return Err(DumpletError::IoError(io::Error::new(
+            io::ErrorKind::Other,
+            "Failed to extract rootfs",
+        )));
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Description
This PR refactors the **Dumplet** library to allow **direct usage as a library**, returning a `File` containing the final `initramfs.img`.  
It introduces a **clean separation of concerns** and enables **easy integration** in other Rust projects.
