### PR TITLE
feat: added ascii armored key serialization

### DIFF
--- a/api/proto/release-agent/controller.proto
+++ b/api/proto/release-agent/controller.proto
@@ -14,20 +14,23 @@ enum CreateReleaseStatus {
 
 message CreateReleaseResponse {
   CreateReleaseStatus status = 1;
-  string release_id = 2;
+  PublicKey public_key = 2;
+  string release_id = 3;
 }
 
 message PublicKey {
-  string key_id = 1;
+  string fingerprint = 1;
   string key_data = 2;
 }
 
-message RollPGPKeysRequest { string algorithm = 1; }
+message RevokePGPKeyRequest {
+  string fingerprint = 1;
+}
 
 message Empty { string dummy = 1; }
 
 service ReleaseAgent {
   rpc CreateRelease(CreateReleaseRequest) returns (CreateReleaseResponse);
-  rpc RollPGPKeys(RollPGPKeysRequest) returns (PublicKey);
-  rpc GetPublicKey(Empty) returns (PublicKey);
+  rpc RevokePGPKey(RevokePGPKeyRequest) returns (CreateReleaseResponse);
+  rpc GetRootPublicKey(Empty) returns (PublicKey);
 }

--- a/release-agent/Cargo.lock
+++ b/release-agent/Cargo.lock
@@ -1974,6 +1974,7 @@ dependencies = [
  "prost",
  "sequoia-openpgp",
  "tar",
+ "tempfile",
  "tokio",
  "tonic",
  "tonic-build",

--- a/release-agent/Cargo.toml
+++ b/release-agent/Cargo.toml
@@ -18,6 +18,7 @@ tonic = "*"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 sequoia-openpgp = "2.0.0"
+tempfile = "3.20.0"
 
 [build-dependencies]
 tonic-build = "*"

--- a/release-agent/README.md
+++ b/release-agent/README.md
@@ -66,3 +66,32 @@ cargo run -- -p <key-passphrase> --secret-key <path-to-key>/sealci.key --git-pat
 
     Ok(())
 ```
+
+## Architecture
+
+When the release agent starts, it creates a PGP key pair and stores the public key on the filesystem.
+Thus the release agent provides the `GetRootPublicKey` gRPC endpoint to retrieve the public key and so any service that needs verification can use it.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant ReleaseAgent
+
+    ReleaseAgent->>ReleaseAgent: Generate PGP key pair
+    Client->>ReleaseAgent: GetRootPublicKey
+    ReleaseAgent->>Client: Public key as ASCII armored
+```
+
+The release agent also provides the `CreateRelease` gRPC endpoint that creates a release and stores it in a S3 bucket.
+ 
+```mermaid
+sequenceDiagram
+    participant Client
+    participant ReleaseAgent
+    participant S3
+
+    Client->>ReleaseAgent: CreateRelease
+    ReleaseAgent->>ReleaseAgent: Sign release
+    ReleaseAgent->>S3: Store release
+    ReleaseAgent->>Client: Release data
+```

--- a/release-agent/src/bin/main.rs
+++ b/release-agent/src/bin/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use std::{path::PathBuf, sync::Arc};
 use sealci_release_agent::{
-    app::AppConfig, bucket::minio::MinioClient, compress::Flate2Client, core::{ReleaseAgentError}, git::Git2Client, sign::SequoiaPGPSigner
+    app::AppConfig, bucket::minio::MinioClient, compress::Flate2Client, core::{ReleaseAgentError}, git::Git2Client, sign::SequoiaPGPManager
 };
 
 #[derive(Debug, Parser)]
@@ -41,7 +41,7 @@ async fn main() -> Result<(), ReleaseAgentError> {
     let cert_path = PathBuf::from(config.secret_key);
 
     // add signer
-    let signer = SequoiaPGPSigner::new(cert_path, config.passphrase)?;
+    let signer = SequoiaPGPManager::new(cert_path, config.passphrase)?;
     // add bucket
     let bucket_client = MinioClient::new(config.bucket_addr, config.bucket_access_key, config.bucket_secret_key, config.bucket_name).await?;
     // add git

--- a/release-agent/src/lib/file.rs
+++ b/release-agent/src/lib/file.rs
@@ -1,0 +1,212 @@
+use std::{
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+
+use tempfile::NamedTempFile;
+
+use sequoia_openpgp::{
+    self as openpgp, armor,
+    serialize::stream::{Armorer, Message},
+};
+use tracing::error;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AscFile{
+    pub path: PathBuf,
+}
+
+#[derive(Debug)]
+pub enum FileError {
+    Io(io::Error),
+    OpenPgp,
+    FileError,
+}
+
+impl AscFile {
+    /// Opens the file (or stdout) for writing data that is safe for
+    /// non-interactive use because it is an OpenPGP data stream.
+    ///
+    /// Emitting armored data with the label `armor::Kind::SecretKey`
+    /// implicitly configures this output to emit secret keys.
+    pub fn create_pgp_safe<'a>(
+        &self,
+        binary: bool,
+        kind: armor::Kind,
+    ) -> Result<Message<'a>, FileError> {
+        // Allow secrets to be emitted if the armor label says secret
+        // key.
+        let o = self.clone();
+        let sink = o.create()?;
+
+        let mut message = Message::new(sink);
+        if !binary {
+            message = Armorer::new(message)
+                .kind(kind)
+                .build()
+                .map_err(|_| FileError::OpenPgp)?;
+        }
+        Ok(message)
+    }
+
+    /// Helper function, do not use directly. Instead, use create_or_stdout_safe
+    /// or create_or_stdout_unsafe.
+    fn create(&self) -> Result<Box<dyn Write + Sync + Send>, FileError> {
+        let sink = self._create_sink()?;
+        if !cfg!(debug_assertions) {
+            // We either expect secrets, or we are in release mode.
+            Ok(sink)
+        } else {
+            // In debug mode, if we don't expect secrets, scan the
+            // output for inadvertently leaked secret keys.
+            Ok(Box::new(SecretLeakDetector::new(sink)))
+        }
+    }
+    fn _create_sink(&self) -> Result<Box<dyn Write + Sync + Send>, FileError> {
+        let path = self.path.clone();
+        Ok(Box::new(
+            PartFileWriter::create(path).expect("Failed to create output file"),
+        ))
+    }
+
+    pub fn path(&self) -> PathBuf {
+        self.path.clone()
+    }
+}
+
+/// A writer that writes to a temporary file first, then persists the
+/// file under the desired name.
+///
+/// This has two benefits.  First, consumers only see the file once we
+/// are done writing to it, i.e. they don't see a partial file.
+///
+/// Second, we guarantee not to overwrite the file until the operation
+/// is finished.  Therefore, it is safe to use the same file as input
+/// and output.
+struct PartFileWriter {
+    path: PathBuf,
+    sink: Option<NamedTempFile>,
+}
+
+impl io::Write for PartFileWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.sink().unwrap().write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.sink().unwrap().flush()
+    }
+}
+
+impl Drop for PartFileWriter {
+    fn drop(&mut self) {
+        if let Err(e) = self.persist() {
+            error!("Error: {:?}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+impl PartFileWriter {
+    /// Opens a file for writing.
+    ///
+    /// The file will be created under a different name in the target
+    /// directory, and will only be renamed to `path` once
+    /// [`PartFileWriter::persist`] is called or the object is
+    /// dropped.
+    pub fn create<P: AsRef<Path>>(path: P) -> Result<PartFileWriter, FileError> {
+        let path = path.as_ref().to_path_buf();
+        let parent = path.parent().ok_or(FileError::FileError)?;
+        let file_name = path.file_name().ok_or(FileError::FileError)?;
+
+        let mut sink = tempfile::Builder::new();
+
+        // By default, temporary files are 0x600 on Unix.  But, we
+        // rather want created files to respect umask.
+        use std::os::unix::fs::PermissionsExt;
+        let all_read_write = std::fs::Permissions::from_mode(0o666);
+
+        // The permissions will be masked by the user's umask.
+        sink.permissions(all_read_write);
+
+        let sink = sink.prefix(file_name).suffix(".part").tempfile_in(parent).map_err(|_| FileError::FileError)?;
+
+        Ok(PartFileWriter {
+            path,
+            sink: Some(sink),
+        })
+    }
+
+    /// Returns a mutable reference to the file, or an error.
+    fn sink(&mut self) -> Result<&mut NamedTempFile, FileError> {
+        self.sink.as_mut().ok_or(FileError::FileError)
+    }
+
+    /// Persists the file under its final name.
+    pub fn persist(&mut self) -> Result<(), FileError> {
+        if let Some(file) = self.sink.take() {
+            file.persist(&self.path).map_err(|_| FileError::FileError)?;
+        }
+        Ok(())
+    }
+}
+
+/// A writer that buffers all data, and scans for secret keys on drop.
+///
+/// This is used to assert that we only write secret keys in places
+/// where we expect that.  As this buffers all data, and has a
+/// performance impact, we only do this in debug builds.
+struct SecretLeakDetector<W: io::Write + Send + Sync> {
+    sink: W,
+    data: Vec<u8>,
+}
+
+impl<W: io::Write + Send + Sync> io::Write for SecretLeakDetector<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let n = self.sink.write(buf)?;
+        self.data.extend_from_slice(&buf[..n]);
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.sink.flush()
+    }
+}
+
+impl<W: io::Write + Send + Sync> Drop for SecretLeakDetector<W> {
+    fn drop(&mut self) {
+        let _ = self.detect_leaks();
+    }
+}
+
+impl<W: io::Write + Send + Sync> SecretLeakDetector<W> {
+    /// Creates a shim around `sink` that scans for inadvertently
+    /// leaked secret keys.
+    fn new(sink: W) -> Self {
+        SecretLeakDetector {
+            sink,
+            data: Vec::with_capacity(4096),
+        }
+    }
+
+    /// Scans the buffered data for secret keys, panic'ing if one is
+    /// found.
+    fn detect_leaks(&self) -> Result<(), FileError> {
+        use openpgp::Packet;
+        use openpgp::parse::{PacketParser, PacketParserResult, Parse};
+
+        let mut ppr = PacketParser::from_bytes(&self.data).map_err(|_| FileError::OpenPgp)?;
+        while let PacketParserResult::Some(pp) = ppr {
+            match &pp.packet {
+                Packet::SecretKey(_) | Packet::SecretSubkey(_) => {
+                    panic!("Leaked secret key: {:?}", pp.packet)
+                }
+                _ => (),
+            }
+            let (_, next_ppr) = pp.recurse().map_err(|_| FileError::OpenPgp)?;
+            ppr = next_ppr;
+        }
+
+        Ok(())
+    }
+}

--- a/release-agent/src/lib/lib.rs
+++ b/release-agent/src/lib/lib.rs
@@ -5,3 +5,4 @@ pub mod sign;
 pub mod git;
 pub mod compress;
 pub mod app;
+pub mod file;

--- a/release-agent/src/lib/sign.rs
+++ b/release-agent/src/lib/sign.rs
@@ -1,48 +1,106 @@
-use std::{fs::{File, OpenOptions}, io::{Read, Write}, path::PathBuf};
-use std::sync::RwLock;
 use sequoia_openpgp::{
-    Cert,
-    armor::Kind,
-    crypto::{KeyPair, Password},
-    parse::Parse,
-    policy::StandardPolicy,
-    serialize::stream::{Armorer, Message, Signer as OpenPgpSigner},
+    armor::{self, Kind}, cert::CertBuilder, crypto::{KeyPair, Password}, packet::prelude::Packet, parse::Parse, policy::StandardPolicy, serialize::{
+        stream::{Armorer, Message, Signer as OpenPgpSigner}, Serialize
+    }, Cert
+};
+use std::{
+    fs::{File, OpenOptions},
+    path::PathBuf,
 };
 
-use tracing::error;
-use minisign::SecretKey;
 use tonic::async_trait;
+use tracing::{error, info};
 
-use tracing::info;
-use crate::core::ReleaseAgentError;
+use crate::{core::{self, ReleaseAgentError}, file::AscFile};
 
-///! A trait for signing releases.
-/// This trait is used to sign a release archive, such as a tarball or zip file,
-/// The return file is the signed archive, which can be used for distribution.
-/// The private key is used to sign the archive.
 #[async_trait]
 pub trait ReleaseSigner: Clone + Send + Sync {
     // file_path is the path to the file to be signed
-    fn sign_release(&self, file_path: PathBuf) -> Result<PathBuf, ReleaseAgentError>;
+    fn sign_release(
+        &self,
+        file_path: PathBuf,
+    ) -> Result<(core::PublicKey, PathBuf), ReleaseAgentError>;
+
+    fn get_public_key(&self) -> Result<core::PublicKey, ReleaseAgentError>;
 }
 
 #[derive(Clone)]
-pub struct SequoiaPGPSigner {
+pub struct SequoiaPGPManager {
     key_pair: KeyPair,
+    cert: Cert,
+    root_public_key: PathBuf,
 }
 
-impl SequoiaPGPSigner {
+impl SequoiaPGPManager {
     pub fn new(cert_path: PathBuf, passphrase: String) -> Result<Self, ReleaseAgentError> {
-        let key_pair_guard = Self::cert_file_to_keypair(cert_path, passphrase)?;
-        Ok(Self {
-            key_pair: key_pair_guard.clone(),
-        })
+        info!("Generating root key pair");
+        let (key_pair, cert, root_public_key) = Self::generate_keypair(passphrase, cert_path)?;
+        info!("Root key pair generated");
+        Ok(Self { key_pair, cert, root_public_key })
     }
 
-    fn cert_file_to_keypair(cert_path: PathBuf, passphrase: String) -> Result<KeyPair, ReleaseAgentError> {
-        let cert = Cert::from_file(cert_path).map_err(|_| ReleaseAgentError::KeyLoadingError)?;
-        cert
+    fn generate_keypair(
+        passphrase: String,
+        path: PathBuf,
+    ) -> Result<(KeyPair, Cert, PathBuf), ReleaseAgentError> {
+        let now = std::time::SystemTime::now();
+        // a year
+        let expiration = std::time::Duration::new(60 * 60 * 24 * 365, 0);
+        let (cert, _) = CertBuilder::new()
+            .add_userid("SealCI Release Agent <release-agent@sealci.dev>")
+            .add_signing_subkey()
+            .set_creation_time(now)
+            .set_validity_period(expiration)
+            .set_password(Some(passphrase.clone().into()))
+            .generate()
+            .map_err(|_| ReleaseAgentError::KeyGenerationError)?;
+        info!("Generated key pair");
+
+
+        let key_pair = cert
             .keys()
+            .with_policy(&StandardPolicy::new(), None)
+            .alive()
+            .revoked(false)
+            .for_signing()
+            .secret()
+            .next()
+            .ok_or(ReleaseAgentError::KeyNotFoundError)?
+            .key()
+            .clone()
+            .decrypt_secret(&Password::from(passphrase))
+            .map_err(|_| ReleaseAgentError::KeyDecryptionError)?
+            .into_keypair()
+            .map_err(|_| ReleaseAgentError::KeyDecryptionError)?;
+        let cert_path = path.join("sealci-release-agent.asc");
+
+        let output = AscFile{
+            path: cert_path.clone(),
+        };
+        let mut sink = output.create_pgp_safe(false, armor::Kind::PublicKey).map_err(|e| {
+            error!("Error creating armored message: {:?}", e);
+            ReleaseAgentError::SigningError
+        })?;
+        cert.serialize(&mut sink).map_err(|e| {
+            error!("Error serializing public key: {}", e);
+            ReleaseAgentError::SigningError
+        })?;
+
+        sink.finalize().map_err(|e| {
+            error!("Error finalizing public key: {}", e);
+            ReleaseAgentError::SigningError
+        })?;
+
+
+        Ok((key_pair, cert, cert_path))
+    }
+
+    fn cert_file_to_keypair(
+        cert_path: PathBuf,
+        passphrase: String,
+    ) -> Result<KeyPair, ReleaseAgentError> {
+        let cert = Cert::from_file(cert_path).map_err(|_| ReleaseAgentError::KeyLoadingError)?;
+        cert.keys()
             .with_policy(&StandardPolicy::new(), None)
             .alive()
             .revoked(false)
@@ -57,24 +115,42 @@ impl SequoiaPGPSigner {
             .into_keypair()
             .map_err(|_| ReleaseAgentError::KeyDecryptionError)
     }
-
 }
 
 #[async_trait]
-impl ReleaseSigner for SequoiaPGPSigner {
-    fn sign_release(&self,file_path: PathBuf) -> Result<PathBuf, ReleaseAgentError> {
+impl ReleaseSigner for SequoiaPGPManager {
+    fn sign_release(
+        &self,
+        file_path: PathBuf,
+    ) -> Result<(core::PublicKey, PathBuf), ReleaseAgentError> {
         let key_pair = self.key_pair.clone();
+        let public_key = self.cert.primary_key().key();
+        let fingerprint = public_key.fingerprint().to_string();
+
+        let serialized_key_file = File::open(self.root_public_key.clone()).map_err(|e| {
+            error!("Error opening public key file: {}", e);
+            ReleaseAgentError::SigningError
+        })?;
+        let serialized_key: String = std::io::read_to_string(serialized_key_file).map_err(|e| {
+            error!("Error reading public key file: {}", e);
+            ReleaseAgentError::SigningError
+        })?;
         let signature_path = PathBuf::from(format!("{}.sig", file_path.display()));
         let signature_file = File::create(signature_path.clone()).map_err(|e| {
             error!("Error creating signature file: {}", e);
             ReleaseAgentError::SigningError
         })?;
 
+        // testing something here
+
         let signature_message = Message::new(signature_file);
-        let armored_message = Armorer::new(signature_message).kind(Kind::Signature).build().map_err(|e| {
-            error!("Error creating armored message: {}", e);
-            ReleaseAgentError::SigningError
-        })?;
+        let armored_message = Armorer::new(signature_message)
+            .kind(Kind::Signature)
+            .build()
+            .map_err(|e| {
+                error!("Error creating armored message: {}", e);
+                ReleaseAgentError::SigningError
+            })?;
 
         let signer = OpenPgpSigner::new(armored_message, key_pair.clone()).map_err(|_| {
             error!("Error creating OpenPGP signer");
@@ -86,16 +162,17 @@ impl ReleaseSigner for SequoiaPGPSigner {
             ReleaseAgentError::SigningError
         })?;
 
-        let mut compressed_archived = OpenOptions::new()
-            .read(true)
-            .open(file_path)
-            .map_err(|e| {
+        let mut compressed_archived =
+            OpenOptions::new().read(true).open(file_path).map_err(|e| {
                 error!("Error opening file to sign: {}", e);
                 ReleaseAgentError::SigningError
             })?;
 
         std::io::copy(&mut compressed_archived, &mut detached_signer_writer).map_err(|e| {
-            error!("Error copying compressed archive to detached signer writer {}", e);
+            error!(
+                "Error copying compressed archive to detached signer writer {}",
+                e
+            );
             ReleaseAgentError::SigningError
         })?;
 
@@ -104,6 +181,31 @@ impl ReleaseSigner for SequoiaPGPSigner {
             ReleaseAgentError::SigningError
         })?;
 
-        Ok(signature_path)
+        Ok((
+            core::PublicKey {
+                key_data: serialized_key,
+                fingerprint,
+            },
+            signature_path,
+        ))
+    }
+
+    fn get_public_key(&self) -> Result<core::PublicKey, ReleaseAgentError> {
+        let public_key = self.cert.primary_key().key();
+        let fingerprint = public_key.fingerprint().to_string();
+
+        let serialized_key_file = File::open(self.root_public_key.clone()).map_err(|e| {
+            error!("Error opening public key file: {}", e);
+            ReleaseAgentError::SigningError
+        })?;
+        let serialized_key: String = std::io::read_to_string(serialized_key_file).map_err(|e| {
+            error!("Error reading public key file: {}", e);
+            ReleaseAgentError::SigningError
+        })?;
+
+        Ok(core::PublicKey {
+            key_data: serialized_key,
+            fingerprint,
+        })
     }
 }


### PR DESCRIPTION
Now when the release agent starts it generates a root PGP key pair. When a release is created, it sends to the caller the public pgp key as an ascii armored string associated to the release : 

![image](https://github.com/user-attachments/assets/d9c94d0a-a57d-4512-8f69-d174c0fd35ed)

These modifications lay the basis for the revocation mechanism :)