### PR TITLE
feat: added dns option to define dns nameserver

### DIFF
--- a/compactor/src/cli.rs
+++ b/compactor/src/cli.rs
@@ -30,4 +30,7 @@ pub struct Cli {
 
     #[arg(long, default_value = "4", help = "Number of virtual CPUs")]
     pub num_vcpus: u8,
+
+    #[arg(long, help = "Nameserver to use for DNS resolution")]
+    pub dns: Option<String>,
 }

--- a/compactor/src/lib.rs
+++ b/compactor/src/lib.rs
@@ -21,7 +21,7 @@ impl Compactor {
             envs.push(env.as_str());
         }
         let initramfs =
-            dumplet::generate_initramfs_image(&config.image, Some(envs), config.transfer_files)
+            dumplet::generate_initramfs_image(&config.image, Some(envs), config.transfer_files, config.dns)
                 .await
                 .map_err(Error::DumpletError)?;
         let vmm_config = dumper::config::VmmConfig {

--- a/dumplet/src/initramfs.rs
+++ b/dumplet/src/initramfs.rs
@@ -60,13 +60,16 @@ pub fn create_initramfs(
     perms.set_mode(0o755);
     fs::set_permissions(&init_path, perms)?;
 
-    let mut resolv_conf = File::create(rootfs_path.join("etc/resolv.conf"))?;
-    match nameserver {
-        Some(nameserver) => {
-            resolv_conf.write_all(format!("nameserver {}\n", nameserver).as_bytes())?;
-        }
-        None => {
-            resolv_conf.write_all(b"nameserver 8.8.8.8\n")?;
+    // check if /etc exists
+    if rootfs_path.join("etc").try_exists()? {
+        let mut resolv_conf = File::create(rootfs_path.join("etc/resolv.conf"))?;
+        match nameserver {
+            Some(nameserver) => {
+                resolv_conf.write_all(format!("nameserver {}\n", nameserver).as_bytes())?;
+            }
+            None => {
+                resolv_conf.write_all(b"nameserver 8.8.8.8\n")?;
+            }
         }
     }
 

--- a/dumplet/src/lib.rs
+++ b/dumplet/src/lib.rs
@@ -26,6 +26,7 @@ pub async fn generate_initramfs_bundle(
     output_dir: &str,
     env: Option<Vec<&str>>,
     transfer_files: Vec<String>,
+    nameserver: Option<String>,
 ) -> Result<DumpletBundle, DumpletError> {
     let output_path = Path::new(output_dir);
     fs::create_dir_all(output_path)?;
@@ -46,6 +47,7 @@ pub async fn generate_initramfs_bundle(
         container_cmd,
         working_dir,
         transfer_files,
+        nameserver,
     )?;
 
     Ok(DumpletBundle {
@@ -60,12 +62,13 @@ pub async fn generate_initramfs_image(
     image: &str,
     env: Option<Vec<&str>>,
     transfer_files: Vec<String>,
+    nameserver: Option<String>,
 ) -> Result<File, DumpletError> {
     let temp_dir = tempdir()?;
     let temp_path = temp_dir.path();
 
     let bundle =
-        generate_initramfs_bundle(image, temp_path.to_str().unwrap(), env, transfer_files).await?;
+        generate_initramfs_bundle(image, temp_path.to_str().unwrap(), env, transfer_files, nameserver).await?;
     let file = File::open(&bundle.initramfs_img)?;
 
     println!(


### PR DESCRIPTION
## Added option to define dns nameserver 
When running : 

```bash
sudo cargo run -- alpine:latest --env DEBUG=true LOG_LEVEL=info --tap-interface-name tap0 --it --dns 1.1.1.1
```
The etc/resolv.conf file will look like that : 
![image](https://github.com/user-attachments/assets/0a57f0b9-42c1-4b91-9307-d03600aedb3e)

By default the nameserver will be `8.8.8.8`

## Motivation : 

Docker by design prohibits editing `/etc/resolv.conf` while building a container because docker does some shenanigans about dns and resolv.conf at runtime. https://stackoverflow.com/questions/41032744/unable-to-edit-etc-resolv-conf-in-docker-container
