### PR TITLE
feat: added grpc + database to save releases

### DIFF
--- a/controller/build.rs
+++ b/controller/build.rs
@@ -7,5 +7,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &["../api/proto/scheduler"],
         )
         .expect("Building scheduler protobuf failed");
+
+    tonic_build::configure()
+        .build_server(false)
+        .compile(
+            &["../api/proto/release-agent/controller.proto"],
+            &["../api/proto/release-agent"],
+        )
+        .expect("Building scheduler protobuf failed");
     Ok(())
 }

--- a/controller/migrations/20250610181635_create-public-key.sql
+++ b/controller/migrations/20250610181635_create-public-key.sql
@@ -1,0 +1,9 @@
+-- Add migration script here
+CREATE TABLE releases (
+  id BIGSERIAL PRIMARY KEY,
+  repo_url VARCHAR(255) NOT NULL,
+  revision VARCHAR(255) NOT NULL,
+  path VARCHAR(255) NOT NULL,
+  public_key TEXT NOT NULL,
+  fingerprint VARCHAR(255) NOT NULL
+);

--- a/controller/src/bin/main.rs
+++ b/controller/src/bin/main.rs
@@ -52,6 +52,16 @@ struct Args {
     ///   --grpc http://127.0.0.1:50051
     #[clap(env, long)]
     pub grpc: String,
+
+    /// gRPC release agent service endpoint.
+    /// Precedence:
+    /// 1. --release-agent CLI flag
+    /// 2. RELEASE_AGENT env var
+    /// If unset, clap will report an error.
+    /// Example:
+    ///   --release-agent http://127.0.0.1:50051
+    #[clap(env, long)]
+    pub release_agent: String,
 }
 
 #[actix_web::main]
@@ -74,6 +84,7 @@ async fn main() -> std::io::Result<()> {
     let app_context: AppContext = AppContext::initialize(
         &args.database_url,
         &args.grpc,
+        &args.release_agent,
     ).await.expect("REASON");
 
     // Initialize tracing subscriber for logging

--- a/controller/src/bin/main.rs
+++ b/controller/src/bin/main.rs
@@ -4,20 +4,8 @@ use clap::Parser;
 use controller::application::app_context::AppContext;
 use controller::application::http::pipeline::router::configure as configure_pipeline_routes;
 use controller::application::http::release::router::configure as configure_release_routes;
-use controller::application::services::action_service::ActionServiceImpl;
-use controller::application::services::command_service::CommandServiceImpl;
-use controller::application::services::pipeline_service::PipelineServiceImpl;
-use controller::application::services::scheduler_service_impl::SchedulerServiceImpl;
-use controller::infrastructure::db::postgres::Postgres;
-use controller::infrastructure::grpc::grpc_scheduler_client::GrpcSchedulerClient;
-use controller::infrastructure::repositories::action_repository::PostgresActionRepository;
-use controller::infrastructure::repositories::command_repository::PostgresCommandRepository;
-use controller::infrastructure::repositories::log_repository::PostgresLogRepository;
-use controller::infrastructure::repositories::pipeline_repository::PostgresPipelineRepository;
 use controller::{docs, health};
 use dotenv::dotenv;
-use futures::lock::Mutex;
-use std::sync::Arc;
 use tracing::info;
 
 #[derive(Parser, Debug)]
@@ -66,7 +54,6 @@ struct Args {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-
     // Load .env file into OS environment variables before parsing clap args.
     // This ensures HTTP, DATABASE_URL, GRPC can be defined in .env and picked up here.
     dotenv().ok();
@@ -81,18 +68,16 @@ async fn main() -> std::io::Result<()> {
     let addr_in: String = args.http;
 
     // Initialize application context with database and gRPC service configurations
-    let app_context: AppContext = AppContext::initialize(
-        &args.database_url,
-        &args.grpc,
-        &args.release_agent,
-    ).await.expect("REASON");
+    let app_context: AppContext =
+        AppContext::initialize(&args.database_url, &args.grpc, &args.release_agent)
+            .await
+            .expect("REASON");
 
     // Initialize tracing subscriber for logging
     tracing_subscriber::fmt::init();
-    
 
     info!("Listening on {}", addr_in);
-    
+
     // Start HTTP server with CORS, logging middleware, and configured routes
     HttpServer::new(move || {
         // Configure CORS to allow any origin/method/header, cache preflight for 1 hour

--- a/controller/src/lib/application/app_context.rs
+++ b/controller/src/lib/application/app_context.rs
@@ -1,8 +1,8 @@
-use tokio::time::{sleep, Duration};
-use tracing::error;
 use futures::lock::Mutex;
 use std::sync::Arc;
 use thiserror::Error;
+use tokio::time::{sleep, Duration};
+use tracing::error;
 
 #[derive(Error, Debug)]
 pub enum AppError {
@@ -10,34 +10,74 @@ pub enum AppError {
     SchedulerConnectionError,
 }
 
-use crate::
+use crate::{
+    application::services::release_service::ReleaseServiceImpl,
     infrastructure::{
         db::postgres::Postgres,
-        grpc::grpc_scheduler_client::GrpcSchedulerClient,
+        grpc::{
+            grpc_release_agent_client::GrpcReleaseAgentClient,
+            grpc_scheduler_client::GrpcSchedulerClient,
+        },
         repositories::{
             action_repository::PostgresActionRepository,
-            command_repository::PostgresCommandRepository, log_repository::PostgresLogRepository,
+            command_repository::PostgresCommandRepository,
+            log_repository::PostgresLogRepository,
             pipeline_repository::PostgresPipelineRepository,
+            release_repository::{self, PostgresReleaseRepository},
         },
-    }
-;
+    },
+};
 
-use super::
-    services::{
-        action_service::ActionServiceImpl, command_service::CommandServiceImpl,
-        pipeline_service::PipelineServiceImpl, scheduler_service_impl::SchedulerServiceImpl,
-    }
-;
+use super::services::{
+    action_service::ActionServiceImpl, command_service::CommandServiceImpl,
+    pipeline_service::PipelineServiceImpl, scheduler_service_impl::SchedulerServiceImpl,
+};
 
 #[derive(Clone)]
 pub struct AppContext {
-    pub pipeline_service: Arc<PipelineServiceImpl<PostgresPipelineRepository, PostgresLogRepository, ActionServiceImpl<PostgresActionRepository, CommandServiceImpl<PostgresCommandRepository>>, SchedulerServiceImpl<ActionServiceImpl<PostgresActionRepository, CommandServiceImpl<PostgresCommandRepository>>, GrpcSchedulerClient, PostgresPipelineRepository>>>,
-    pub action_service: Arc<ActionServiceImpl<PostgresActionRepository, CommandServiceImpl<PostgresCommandRepository>>>,
-    pub scheduler_service: Arc<Mutex<SchedulerServiceImpl<ActionServiceImpl<PostgresActionRepository, CommandServiceImpl<PostgresCommandRepository>>, GrpcSchedulerClient, PostgresPipelineRepository>>>,
+    pub pipeline_service: Arc<
+        PipelineServiceImpl<
+            PostgresPipelineRepository,
+            PostgresLogRepository,
+            ActionServiceImpl<
+                PostgresActionRepository,
+                CommandServiceImpl<PostgresCommandRepository>,
+            >,
+            SchedulerServiceImpl<
+                ActionServiceImpl<
+                    PostgresActionRepository,
+                    CommandServiceImpl<PostgresCommandRepository>,
+                >,
+                GrpcSchedulerClient,
+                PostgresPipelineRepository,
+            >,
+        >,
+    >,
+    pub action_service: Arc<
+        ActionServiceImpl<PostgresActionRepository, CommandServiceImpl<PostgresCommandRepository>>,
+    >,
+    pub scheduler_service: Arc<
+        Mutex<
+            SchedulerServiceImpl<
+                ActionServiceImpl<
+                    PostgresActionRepository,
+                    CommandServiceImpl<PostgresCommandRepository>,
+                >,
+                GrpcSchedulerClient,
+                PostgresPipelineRepository,
+            >,
+        >,
+    >,
+    pub release_service:
+        Arc<Mutex<ReleaseServiceImpl<GrpcReleaseAgentClient, PostgresReleaseRepository>>>,
 }
 
 impl AppContext {
-    pub async fn initialize(database_url: &str, grpc_url: &str) -> Result<Self, AppError> {
+    pub async fn initialize(
+        database_url: &str,
+        grpc_url: &str,
+        release_agent_url: &str,
+    ) -> Result<Self, AppError> {
         // Initialize Postgres connection pool using provided database URL
         let postgres = Arc::new(Postgres::new(database_url).await);
 
@@ -54,7 +94,32 @@ impl AppContext {
                     if retry_count >= 10 {
                         return Err(AppError::SchedulerConnectionError);
                     }
-                    error!("Failed to connect to scheduler: {}, retrying in {:?} seconds...", e, retry_delay);
+                    error!(
+                        "Failed to connect to scheduler: {}, retrying in {:?} seconds...",
+                        e, retry_delay
+                    );
+                    sleep(retry_delay).await;
+                    retry_delay *= 2;
+                    if retry_delay > Duration::from_secs(MAX_RETRY_DELAY) {
+                        retry_delay = Duration::from_secs(MAX_RETRY_DELAY);
+                    }
+                    retry_count += 1;
+                }
+            }
+        };
+        let mut retry_delay = Duration::from_secs(2);
+        let mut retry_count = 0;
+        let release_agent_grpc_client = loop {
+            match GrpcReleaseAgentClient::new(release_agent_url).await {
+                Ok(client) => break client,
+                Err(e) => {
+                    if retry_count >= 10 {
+                        return Err(AppError::SchedulerConnectionError);
+                    }
+                    error!(
+                        "Failed to connect to release agent: {}, retrying in {:?} seconds...",
+                        e, retry_delay
+                    );
                     sleep(retry_delay).await;
                     retry_delay *= 2;
                     if retry_delay > Duration::from_secs(MAX_RETRY_DELAY) {
@@ -67,10 +132,13 @@ impl AppContext {
 
         // Wrap gRPC client in async Mutex for shared state
         let scheduler_client = Arc::new(Mutex::new(grpc_client));
+        let release_agent_client = Arc::new(Mutex::new(release_agent_grpc_client));
 
         let command_repository = Arc::new(PostgresCommandRepository::new(postgres.clone()));
 
         let action_repository = Arc::new(PostgresActionRepository::new(postgres.clone()));
+
+        let release_repository = Arc::new(PostgresReleaseRepository::new(postgres.clone()));
 
         let command_service = Arc::new(CommandServiceImpl::new(command_repository));
 
@@ -85,6 +153,11 @@ impl AppContext {
             pipeline_repository.clone(),
         )));
 
+        let release_service = Arc::new(Mutex::new(ReleaseServiceImpl::new(
+            release_agent_client,
+            release_repository,
+        )));
+
         let pipeline_service = Arc::new(PipelineServiceImpl::new(
             pipeline_repository.clone(),
             log_repository.clone(),
@@ -96,6 +169,7 @@ impl AppContext {
             pipeline_service,
             action_service,
             scheduler_service,
+            release_service,
         })
     }
 }

--- a/controller/src/lib/application/app_context.rs
+++ b/controller/src/lib/application/app_context.rs
@@ -68,8 +68,7 @@ pub struct AppContext {
             >,
         >,
     >,
-    pub release_service:
-        Arc<Mutex<ReleaseServiceImpl<GrpcReleaseAgentClient, PostgresReleaseRepository>>>,
+    pub release_service: Arc<ReleaseServiceImpl<GrpcReleaseAgentClient, PostgresReleaseRepository>>,
 }
 
 impl AppContext {
@@ -132,7 +131,7 @@ impl AppContext {
 
         // Wrap gRPC client in async Mutex for shared state
         let scheduler_client = Arc::new(Mutex::new(grpc_client));
-        let release_agent_client = Arc::new(Mutex::new(release_agent_grpc_client));
+        let release_agent_client = Arc::new(release_agent_grpc_client);
 
         let command_repository = Arc::new(PostgresCommandRepository::new(postgres.clone()));
 
@@ -153,10 +152,10 @@ impl AppContext {
             pipeline_repository.clone(),
         )));
 
-        let release_service = Arc::new(Mutex::new(ReleaseServiceImpl::new(
+        let release_service = Arc::new(ReleaseServiceImpl::new(
             release_agent_client,
             release_repository,
-        )));
+        ));
 
         let pipeline_service = Arc::new(PipelineServiceImpl::new(
             pipeline_repository.clone(),

--- a/controller/src/lib/application/app_context.rs
+++ b/controller/src/lib/application/app_context.rs
@@ -20,10 +20,9 @@ use crate::{
         },
         repositories::{
             action_repository::PostgresActionRepository,
-            command_repository::PostgresCommandRepository,
-            log_repository::PostgresLogRepository,
+            command_repository::PostgresCommandRepository, log_repository::PostgresLogRepository,
             pipeline_repository::PostgresPipelineRepository,
-            release_repository::{self, PostgresReleaseRepository},
+            release_repository::PostgresReleaseRepository,
         },
     },
 };

--- a/controller/src/lib/application/http/pipeline/handlers/pipeline.rs
+++ b/controller/src/lib/application/http/pipeline/handlers/pipeline.rs
@@ -2,12 +2,10 @@ use actix_multipart::form::{tempfile::TempFile, text::Text as MpText, MultipartF
 use actix_web::{get, post, web, HttpResponse, Responder};
 use serde::Deserialize;
 use std::io::Read;
-use std::sync::Arc;
 use tracing::{error, info};
 
 use crate::application::app_context::AppContext;
 use crate::application::ports::pipeline_service::PipelineService;
-use crate::application::services::pipeline_service::DefaultPipelineServiceImpl;
 use crate::parser::pipe_parser::{
     ManifestParser, ManifestPipeline as ParserManifestPipeline, ParsingError, PipeParser,
 };
@@ -61,7 +59,11 @@ pub async fn get_pipeline(
     match ctx.pipeline_service.find_by_id(id).await {
         Ok(mut pipeline) => {
             if verbose {
-                if let Err(e) = ctx.pipeline_service.add_verbose_details(&mut pipeline).await {
+                if let Err(e) = ctx
+                    .pipeline_service
+                    .add_verbose_details(&mut pipeline)
+                    .await
+                {
                     error!("Failed to enrich pipeline {} with logs: {:?}", id, e);
                 }
             }
@@ -125,7 +127,8 @@ pub async fn create_pipeline(
         },
     };
 
-    match ctx.pipeline_service
+    match ctx
+        .pipeline_service
         .create_manifest_pipeline(domain_manifest, repo_url)
         .await
     {

--- a/controller/src/lib/application/http/release/handlers/release.rs
+++ b/controller/src/lib/application/http/release/handlers/release.rs
@@ -1,8 +1,11 @@
-use actix_web::{post, web, HttpResponse, Responder};
+use actix_web::{error::InternalError, post, web, HttpResponse, Responder};
 use serde::{Deserialize, Serialize};
 use tracing::{error, info};
 
-use crate::application::app_context::AppContext;
+use crate::{
+    application::{app_context::AppContext, ports::release_service::ReleaseService},
+    domain::releases::entities::ReleaseError,
+};
 
 #[derive(Debug, Deserialize)]
 pub struct ReleaseRequest {
@@ -26,13 +29,45 @@ pub async fn handle_release(
         release_data.repo_url, release_data.tag_name
     );
 
+    let mut release_service = ctx.release_service.lock().await;
+    match release_service
+        .create_release(
+            release_data.repo_url.to_string().as_str(),
+            release_data.tag_name.to_string().as_str(),
+        )
+        .await
+    {
+        Ok(_) => HttpResponse::Ok().json(ReleaseResponse {
+            status: "success".to_string(),
+            message: format!(
+                "Release request received for tag {} on repository {}",
+                release_data.tag_name, release_data.repo_url
+            ),
+        }),
+        Err(ReleaseError::DatabaseError(e)) => {
+            HttpResponse::InternalServerError().json(ReleaseResponse {
+                status: "error".to_string(),
+                message: e.to_string(),
+            })
+        }
+        Err(ReleaseError::NotFound) => HttpResponse::NotFound().json(ReleaseResponse {
+            status: "error".to_string(),
+            message: "Release not found".to_string(),
+        }),
+        Err(ReleaseError::InternalError) => {
+            HttpResponse::InternalServerError().json(ReleaseResponse {
+                status: "error".to_string(),
+                message: "Internal server error :(".to_string(),
+            })
+        }
+        Err(ReleaseError::ReleaseAgentError) => {
+            HttpResponse::InternalServerError().json(ReleaseResponse {
+                status: "error".to_string(),
+                message: "Release agent error :(".to_string(),
+            })
+        }
+    }
+
     // TODO: Implement release handling logic
     // For now, we'll just acknowledge the request
-    HttpResponse::Ok().json(ReleaseResponse {
-        status: "success".to_string(),
-        message: format!(
-            "Release request received for tag {} on repository {}",
-            release_data.tag_name, release_data.repo_url
-        ),
-    })
 }

--- a/controller/src/lib/application/http/release/handlers/release.rs
+++ b/controller/src/lib/application/http/release/handlers/release.rs
@@ -1,6 +1,6 @@
-use actix_web::{error::InternalError, get, post, web, HttpResponse, Responder};
+use actix_web::{get, post, web, HttpResponse, Responder};
 use serde::{Deserialize, Serialize};
-use tracing::{error, info};
+use tracing::info;
 
 use crate::{
     application::{app_context::AppContext, ports::release_service::ReleaseService},

--- a/controller/src/lib/application/http/release/router.rs
+++ b/controller/src/lib/application/http/release/router.rs
@@ -1,6 +1,6 @@
+use crate::application::http::release::handlers::release::{handle_release, list_releases};
 use actix_web::web::ServiceConfig;
-use crate::application::http::release::handlers::release::handle_release;
 
 pub fn configure(cfg: &mut ServiceConfig) {
-    cfg.service(handle_release);
-} 
+    cfg.service(handle_release).service(list_releases);
+}

--- a/controller/src/lib/application/ports.rs
+++ b/controller/src/lib/application/ports.rs
@@ -1,4 +1,5 @@
 pub mod action_service;
 pub mod command_service;
 pub mod pipeline_service;
+pub mod release_service;
 pub mod scheduler_service;

--- a/controller/src/lib/application/ports/release_service.rs
+++ b/controller/src/lib/application/ports/release_service.rs
@@ -1,0 +1,8 @@
+use crate::domain::releases::entities::{Release, ReleaseError};
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait ReleaseService: Send + Sync {
+    async fn create_release(&self, repo_url: &str, revision: &str) -> Result<(), ReleaseError>;
+    async fn list_releases(&self, repo_url: &str) -> Result<Vec<Release>, ReleaseError>;
+}

--- a/controller/src/lib/application/services.rs
+++ b/controller/src/lib/application/services.rs
@@ -1,4 +1,5 @@
 pub mod action_service;
 pub mod command_service;
 pub mod pipeline_service;
+pub mod release_service;
 pub mod scheduler_service_impl;

--- a/controller/src/lib/application/services/release_service.rs
+++ b/controller/src/lib/application/services/release_service.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 use tracing::info;
 
 use crate::{

--- a/controller/src/lib/application/services/release_service.rs
+++ b/controller/src/lib/application/services/release_service.rs
@@ -1,0 +1,71 @@
+use async_trait::async_trait;
+use futures::lock::Mutex;
+use std::{path::PathBuf, sync::Arc};
+
+use crate::{
+    application::ports::release_service::ReleaseService,
+    domain::releases::{
+        entities::{CreateReleaseRequest, Release, ReleaseError, ReleaseStatus},
+        ports::ReleaseRepository,
+        services::ReleaseAgentClient,
+    },
+};
+
+pub struct ReleaseServiceImpl<R, P>
+where
+    R: ReleaseAgentClient + Send + Sync,
+    P: ReleaseRepository + Send + Sync,
+{
+    release_agent_client: Arc<Mutex<R>>,
+    release_repository: Arc<P>,
+}
+
+impl<R, P> ReleaseServiceImpl<R, P>
+where
+    R: ReleaseAgentClient + Send + Sync,
+    P: ReleaseRepository + Send + Sync,
+{
+    pub fn new(release_agent_client: Arc<Mutex<R>>, release_repository: Arc<P>) -> Self {
+        Self {
+            release_agent_client,
+            release_repository,
+        }
+    }
+}
+
+#[async_trait]
+impl<R, P> ReleaseService for ReleaseServiceImpl<R, P>
+where
+    R: ReleaseAgentClient + Send + Sync,
+    P: ReleaseRepository + Send + Sync,
+{
+    async fn create_release(&self, repo_url: &str, revision: &str) -> Result<(), ReleaseError> {
+        let request = CreateReleaseRequest {
+            repo_url: repo_url.to_string(),
+            revision: revision.to_string(),
+        };
+        let client = self.release_agent_client.lock().await;
+        let release_answer = client
+            .release(request)
+            .await
+            .map_err(|_| ReleaseError::InternalError)?;
+        if release_answer.status == ReleaseStatus::FAILURE {
+            return Err(ReleaseError::ReleaseAgentError);
+        }
+        let public_key = release_answer.public_key.unwrap().clone();
+        let _ = self.release_repository.create_release(
+            repo_url.to_string(),
+            revision.to_string(),
+            release_answer.release_id,
+            public_key.key_data,
+            public_key.fingerprint,
+        );
+        Ok(())
+    }
+
+    async fn list_releases(&self, repo_url: &str) -> Result<Vec<Release>, ReleaseError> {
+        self.release_repository
+            .list_releases(repo_url.to_string())
+            .await
+    }
+}

--- a/controller/src/lib/domain.rs
+++ b/controller/src/lib/domain.rs
@@ -1,4 +1,5 @@
 pub mod action;
+pub mod releases;
 pub mod command;
 pub mod pipeline;
 pub mod log;

--- a/controller/src/lib/domain/releases.rs
+++ b/controller/src/lib/domain/releases.rs
@@ -1,0 +1,3 @@
+pub mod entities;
+pub mod services;
+pub mod ports;

--- a/controller/src/lib/domain/releases/entities.rs
+++ b/controller/src/lib/domain/releases/entities.rs
@@ -1,0 +1,69 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Release {
+    pub id: i64,
+    pub repo_url: String,
+    pub revision: String,
+    pub path: String,
+    pub public_key: String,
+    pub fingerprint: String,
+}
+
+impl Release {
+    pub fn new(
+        id: i64,
+        repo_url: String,
+        revision: String,
+        path: String,
+        public_key: String,
+        fingerprint: String,
+    ) -> Release {
+        Release {
+            id,
+            repo_url,
+            revision,
+            path,
+            public_key,
+            fingerprint,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ReleaseError {
+    #[error("Database error: {0}")]
+    DatabaseError(#[from] sqlx::Error),
+    #[error("Release not found")]
+    NotFound,
+    #[error("Internal error")]
+    InternalError,
+    #[error("Release agent error")]
+    ReleaseAgentError,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateReleaseRequest {
+    pub repo_url: String,
+    pub revision: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateReleaseResponse {
+    pub status: ReleaseStatus,
+    pub release_id: String,
+    pub public_key: Option<PublicKey>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PublicKey {
+    pub key_data: String,
+    pub fingerprint: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ReleaseStatus {
+    SUCCESS = 0,
+    FAILURE = 1,
+}

--- a/controller/src/lib/domain/releases/ports.rs
+++ b/controller/src/lib/domain/releases/ports.rs
@@ -1,0 +1,16 @@
+use async_trait::async_trait;
+
+use super::entities::{Release, ReleaseError};
+
+#[async_trait]
+pub trait ReleaseRepository: Send + Sync {
+    async fn create_release(
+        &self,
+        repo_url: String,
+        revision: String,
+        path: String,
+        public_key: String,
+        fingerprint: String,
+    ) -> Result<Release, ReleaseError>;
+    async fn list_releases(&self, repo_url: String) -> Result<Vec<Release>, ReleaseError>;
+}

--- a/controller/src/lib/domain/releases/services.rs
+++ b/controller/src/lib/domain/releases/services.rs
@@ -1,0 +1,7 @@
+use async_trait::async_trait;
+use crate::domain::releases::entities::{CreateReleaseRequest, CreateReleaseResponse};
+
+#[async_trait]
+pub trait ReleaseAgentClient: Send + Sync {
+    async fn release(&self, request: CreateReleaseRequest) -> Result<CreateReleaseResponse, Box<dyn std::error::Error>>;
+}

--- a/controller/src/lib/infrastructure/grpc.rs
+++ b/controller/src/lib/infrastructure/grpc.rs
@@ -1,6 +1,11 @@
 pub mod grpc_scheduler_client;
+pub mod grpc_release_agent_client;
 // import proto_scheduler from the generated protobuf code
 // The scheduler is a folder containing the .proto files for the scheduler service
 pub mod proto_scheduler {
     tonic::include_proto!("scheduler");
+}
+
+pub mod proto_release_agent {
+    tonic::include_proto!("releaseagent");
 }

--- a/controller/src/lib/infrastructure/grpc/grpc_release_agent_client.rs
+++ b/controller/src/lib/infrastructure/grpc/grpc_release_agent_client.rs
@@ -4,14 +4,9 @@ use std::sync::Arc;
 use futures::lock::Mutex;
 use tonic::{transport::Channel, Response};
 
-use crate::{
-    domain::{
-        self,
-        releases::entities::{
-            CreateReleaseRequest, CreateReleaseResponse, PublicKey, ReleaseStatus,
-        },
-    },
-    infrastructure::grpc,
+use crate::domain::{
+    self,
+    releases::entities::{CreateReleaseRequest, CreateReleaseResponse, PublicKey, ReleaseStatus},
 };
 
 use crate::infrastructure::grpc::proto_release_agent::{

--- a/controller/src/lib/infrastructure/grpc/grpc_release_agent_client.rs
+++ b/controller/src/lib/infrastructure/grpc/grpc_release_agent_client.rs
@@ -1,0 +1,99 @@
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use futures::lock::Mutex;
+use tonic::{transport::Channel, Response};
+
+use crate::{
+    domain::{
+        self,
+        releases::entities::{
+            CreateReleaseRequest, CreateReleaseResponse, PublicKey, ReleaseStatus,
+        },
+    },
+    infrastructure::grpc,
+};
+
+use crate::infrastructure::grpc::proto_release_agent::{
+    CreateReleaseRequest as ProtoCreateReleaseRequest,
+    CreateReleaseResponse as ProtoCreateReleaseResponse,
+    CreateReleaseStatus as ProtoCreateReleaseStatus, PublicKey as ProtoPublicKey,
+};
+
+use super::proto_release_agent::release_agent_client::ReleaseAgentClient;
+
+pub struct GrpcReleaseAgentClient {
+    client: Arc<Mutex<ReleaseAgentClient<Channel>>>,
+}
+
+impl GrpcReleaseAgentClient {
+    pub async fn new(grpc_url: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        let client = ReleaseAgentClient::connect(grpc_url.to_string()).await?;
+        tracing::info!("Connected to release agent at {}", grpc_url);
+        Ok(Self {
+            client: Arc::new(Mutex::new(client)),
+        })
+    }
+}
+
+impl From<ProtoPublicKey> for PublicKey {
+    fn from(grpc_key: ProtoPublicKey) -> Self {
+        PublicKey {
+            key_data: grpc_key.key_data,
+            fingerprint: grpc_key.fingerprint,
+        }
+    }
+}
+
+impl From<ProtoCreateReleaseStatus> for ReleaseStatus {
+    fn from(grpc_status: ProtoCreateReleaseStatus) -> Self {
+        match grpc_status {
+            ProtoCreateReleaseStatus::Failure => Self::FAILURE,
+            ProtoCreateReleaseStatus::Success => Self::SUCCESS,
+        }
+    }
+}
+
+impl From<CreateReleaseRequest> for ProtoCreateReleaseRequest {
+    fn from(grpc_request: CreateReleaseRequest) -> Self {
+        ProtoCreateReleaseRequest {
+            repo_url: grpc_request.repo_url,
+            revision: grpc_request.revision,
+        }
+    }
+}
+
+impl From<Response<ProtoCreateReleaseResponse>> for CreateReleaseResponse {
+    fn from(grpc_response: Response<ProtoCreateReleaseResponse>) -> Self {
+        let grpc_response: ProtoCreateReleaseResponse = grpc_response.into_inner();
+        let status = match grpc_response.status() {
+            ProtoCreateReleaseStatus::Failure => ReleaseStatus::FAILURE,
+            ProtoCreateReleaseStatus::Success => ReleaseStatus::SUCCESS,
+        };
+        let key = match grpc_response.public_key {
+            Some(public_key) => Some(PublicKey {
+                fingerprint: public_key.fingerprint,
+                key_data: public_key.key_data,
+            }),
+            None => None,
+        };
+        CreateReleaseResponse {
+            status: status,
+            release_id: grpc_response.release_id,
+            public_key: key,
+        }
+    }
+}
+
+#[async_trait]
+impl domain::releases::services::ReleaseAgentClient for GrpcReleaseAgentClient {
+    async fn release(
+        &self,
+        request: CreateReleaseRequest,
+    ) -> Result<CreateReleaseResponse, Box<dyn std::error::Error>> {
+        let grpc_request: ProtoCreateReleaseRequest = request.into();
+        let mut client = self.client.lock().await;
+        let response: CreateReleaseResponse = client.create_release(grpc_request).await?.into();
+        Ok(response)
+    }
+}

--- a/controller/src/lib/infrastructure/repositories.rs
+++ b/controller/src/lib/infrastructure/repositories.rs
@@ -2,3 +2,4 @@ pub mod action_repository;
 pub mod command_repository;
 pub mod log_repository;
 pub mod pipeline_repository;
+pub mod release_repository;

--- a/controller/src/lib/infrastructure/repositories/release_repository.rs
+++ b/controller/src/lib/infrastructure/repositories/release_repository.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+use async_trait::async_trait;
+
+use crate::{
+    infrastructure::db::postgres::Postgres,
+    domain::releases::{
+        entities::{Release, ReleaseError},
+        ports::{ReleaseRepository},
+    }
+};
+
+
+pub struct PostgresReleaseRepository {
+
+    pub postgres: Arc<Postgres>,
+}
+
+impl PostgresReleaseRepository {
+    pub fn new(postgres: Arc<Postgres>) -> Self {
+        Self { postgres }
+    }
+}
+
+#[async_trait]
+impl ReleaseRepository for PostgresReleaseRepository {
+    async fn create_release(
+        &self,
+        repo_url: String,
+        revision: String,
+        path: String,
+        public_key: String,
+        fingerprint: String,
+    ) -> Result<Release, ReleaseError> {
+        let row = sqlx::query!(
+            "INSERT INTO releases (repo_url, revision, path, public_key, fingerprint) VALUES ($1, $2, $3, $4, $5)
+             RETURNING id, repo_url, revision, path, public_key, fingerprint",
+            repo_url,
+            revision,
+            path,
+            public_key,
+            fingerprint
+        )
+        .fetch_one(&self.postgres.get_pool())
+        .await
+        .map_err(ReleaseError::DatabaseError)?;
+
+        Ok(Release {
+            id: row.id,
+            repo_url: row.repo_url,
+            revision: row.revision,
+            path: row.path,
+            public_key: row.public_key,
+            fingerprint: row.fingerprint,
+        })
+    }
+
+    async fn list_releases(&self, repo_url: String) -> Result<Vec<Release>, ReleaseError> {
+        let rows = sqlx::query!(
+            "SELECT id, repo_url, revision, path, public_key, fingerprint FROM releases WHERE repo_url = $1",
+            repo_url
+        )
+        .fetch_all(&self.postgres.get_pool())
+        .await
+        .map_err(ReleaseError::DatabaseError)?;
+
+        let releases = rows
+            .into_iter()
+            .map(|row| Release {
+                id: row.id,
+                repo_url: row.repo_url,
+                revision: row.revision,
+                path: row.path,
+                public_key: row.public_key,
+                fingerprint: row.fingerprint,
+            })
+            .collect();
+
+        Ok(releases)
+    }
+}

--- a/controller/src/lib/infrastructure/repositories/release_repository.rs
+++ b/controller/src/lib/infrastructure/repositories/release_repository.rs
@@ -1,17 +1,16 @@
-use std::sync::Arc;
 use async_trait::async_trait;
+use std::sync::Arc;
+use tracing::info;
 
 use crate::{
-    infrastructure::db::postgres::Postgres,
     domain::releases::{
         entities::{Release, ReleaseError},
-        ports::{ReleaseRepository},
-    }
+        ports::ReleaseRepository,
+    },
+    infrastructure::db::postgres::Postgres,
 };
 
-
 pub struct PostgresReleaseRepository {
-
     pub postgres: Arc<Postgres>,
 }
 
@@ -31,6 +30,7 @@ impl ReleaseRepository for PostgresReleaseRepository {
         public_key: String,
         fingerprint: String,
     ) -> Result<Release, ReleaseError> {
+        info!("inserting {}", repo_url);
         let row = sqlx::query!(
             "INSERT INTO releases (repo_url, revision, path, public_key, fingerprint) VALUES ($1, $2, $3, $4, $5)
              RETURNING id, repo_url, revision, path, public_key, fingerprint",

--- a/monitor/src/event_listener.rs
+++ b/monitor/src/event_listener.rs
@@ -1,4 +1,4 @@
-use crate::common::{GitEvent, GitTag};
+use crate::common::GitEvent;
 use crate::github::GitHubClient;
 use crate::{controller::ControllerClient, error::Error};
 use std::fs::File;

--- a/release-agent/Cargo.lock
+++ b/release-agent/Cargo.lock
@@ -1633,6 +1633,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.4.2+3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,6 +1649,7 @@ checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2000,6 +2010,7 @@ dependencies = [
  "futures",
  "git2",
  "minio",
+ "openssl",
  "prost",
  "rand 0.9.1",
  "sequoia-openpgp",

--- a/release-agent/Cargo.lock
+++ b/release-agent/Cargo.lock
@@ -1633,15 +1633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.4.2+3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,7 +1640,6 @@ checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2010,7 +2000,6 @@ dependencies = [
  "futures",
  "git2",
  "minio",
- "openssl",
  "prost",
  "rand 0.9.1",
  "sequoia-openpgp",

--- a/release-agent/Cargo.toml
+++ b/release-agent/Cargo.toml
@@ -20,7 +20,6 @@ tracing-subscriber = "0.3.19"
 sequoia-openpgp = "2.0.0"
 tempfile = "3.20.0"
 rand = "0.9.1"
-openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]
 tonic-build = "*"

--- a/release-agent/Cargo.toml
+++ b/release-agent/Cargo.toml
@@ -20,6 +20,7 @@ tracing-subscriber = "0.3.19"
 sequoia-openpgp = "2.0.0"
 tempfile = "3.20.0"
 rand = "0.9.1"
+openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]
 tonic-build = "*"


### PR DESCRIPTION
## What has been done 
- Controller exposes two endpoints to list and create releases
- Controller sends via gRPC to the release agent a release requests
- Controller stores in database release informations

## How to test : 
### 1. Create a release 

```bash
curl --location 'http://0.0.0.0:4000/release' \
--header 'Content-Type: application/json' \
--data '{
    "repo_url": "https://github.com/optique-dev/optique",
    "tag_name": "v0.3.0"
}'
```

### 2. List releases 

```bash
curl --location 'http://localhost:4000/release/optique-dev/optique'
```