### PR TITLE
Feat/public key server

### DIFF
--- a/controller/src/lib/application/http/release/handlers/release.rs
+++ b/controller/src/lib/application/http/release/handlers/release.rs
@@ -130,12 +130,10 @@ pub async fn pks_lookup(
     let fingerprint = fingerprint.split("0x").last().unwrap().to_string();
     let key_result = ctx.release_service.get_key(&fingerprint.clone()).await;
     match key_result {
-        Err(_) => {
-            return HttpResponse::NotFound().json(ReleaseResponse {
+        Err(_) => HttpResponse::NotFound().json(ReleaseResponse {
                 message: format!("Key with fingerprint {} not found", fingerprint),
                 status: "error".to_string(),
-            })
-        }
+            }),
         Ok(key) => HttpResponse::Ok()
             .append_header(("Content-Type", "text/plain"))
             .body(BoxBody::new(key)),

--- a/controller/src/lib/application/http/release/handlers/release.rs
+++ b/controller/src/lib/application/http/release/handlers/release.rs
@@ -1,5 +1,3 @@
-use std::fmt::format;
-
 use actix_web::{body::BoxBody, get, post, web, HttpResponse, Responder};
 use serde::{Deserialize, Serialize};
 use tracing::info;
@@ -127,13 +125,21 @@ pub async fn pks_lookup(
             status: "error".to_string(),
         });
     }
-    let fingerprint = fingerprint.split("0x").last().unwrap().to_string();
+    let fingerprint = match fingerprint.split("0x").last() {
+        Some(fp) => fp.to_string(),
+        None => {
+            return HttpResponse::BadRequest().json(ReleaseResponse {
+                message: "Invalid fingerprint format. Expected '0x' prefix.".to_string(),
+                status: "error".to_string(),
+            });
+        }
+    };
     let key_result = ctx.release_service.get_key(&fingerprint.clone()).await;
     match key_result {
         Err(_) => HttpResponse::NotFound().json(ReleaseResponse {
-                message: format!("Key with fingerprint {} not found", fingerprint),
-                status: "error".to_string(),
-            }),
+            message: format!("Key with fingerprint {} not found", fingerprint),
+            status: "error".to_string(),
+        }),
         Ok(key) => HttpResponse::Ok()
             .append_header(("Content-Type", "text/plain"))
             .body(BoxBody::new(key)),

--- a/controller/src/lib/application/http/release/router.rs
+++ b/controller/src/lib/application/http/release/router.rs
@@ -1,6 +1,10 @@
-use crate::application::http::release::handlers::release::{handle_release, list_releases};
+use crate::application::http::release::handlers::release::{
+    handle_release, list_releases, pks_lookup,
+};
 use actix_web::web::ServiceConfig;
 
 pub fn configure(cfg: &mut ServiceConfig) {
-    cfg.service(handle_release).service(list_releases);
+    cfg.service(handle_release)
+        .service(list_releases)
+        .service(pks_lookup);
 }

--- a/controller/src/lib/application/ports/release_service.rs
+++ b/controller/src/lib/application/ports/release_service.rs
@@ -5,4 +5,5 @@ use async_trait::async_trait;
 pub trait ReleaseService: Send + Sync {
     async fn create_release(&self, repo_url: &str, revision: &str) -> Result<(), ReleaseError>;
     async fn list_releases(&self, repo_url: &str) -> Result<Vec<Release>, ReleaseError>;
+    async fn get_key(&self, fingerprint: &str) -> Result<String, ReleaseError>;
 }

--- a/controller/src/lib/application/services/release_service.rs
+++ b/controller/src/lib/application/services/release_service.rs
@@ -72,4 +72,10 @@ where
             .list_releases(repo_url.to_string())
             .await
     }
+
+    async fn get_key(&self, fingerprint: &str) -> Result<String, ReleaseError> {
+        self.release_repository
+            .get_key(fingerprint.to_string())
+            .await
+    }
 }

--- a/controller/src/lib/domain/releases/ports.rs
+++ b/controller/src/lib/domain/releases/ports.rs
@@ -13,4 +13,5 @@ pub trait ReleaseRepository: Send + Sync {
         fingerprint: String,
     ) -> Result<Release, ReleaseError>;
     async fn list_releases(&self, repo_url: String) -> Result<Vec<Release>, ReleaseError>;
+    async fn get_key(&self, fingerprint: String) -> Result<String, ReleaseError>;
 }


### PR DESCRIPTION
Added possibility to retrieve keys following this IETF spec -> https://www.ietf.org/archive/id/draft-gallagher-openpgp-hkp-04.html

To retrieve a key from a release, do the following : 

```bash
sq network keyserver search --server hkp://localhost:4000 <key-fingerprint>
```